### PR TITLE
Update zip claim verification

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -49,7 +49,7 @@ fn main() {
 
         let reader = ent.reader();
         let inflater = flate2::read::DeflateDecoder::new(reader);
-        let mut verifier = ent.verifier(inflater);
+        let mut verifier = ent.verifying_reader(inflater);
         if let Err(e) = std::io::copy(&mut verifier, &mut out) {
             eprintln!("Failed to copy entry to data: {}", e);
             std::process::exit(1);

--- a/fuzz/fuzz_targets/fuzz_zip.rs
+++ b/fuzz/fuzz_targets/fuzz_zip.rs
@@ -24,7 +24,7 @@ fuzz_target!(|data: &[u8]| {
         }
 
         let inflater = flate2::read::DeflateDecoder::new(ent.reader());
-        let mut verifier = ent.verifier(inflater);
+        let mut verifier = ent.verifying_reader(inflater);
         let mut sink = std::io::sink();
         let Ok(_) = std::io::copy(&mut verifier, &mut sink) else {
             continue;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -31,7 +31,7 @@ fn zip_integration_tests() {
         match entry.compression_method() {
             rawzip::CompressionMethod::Deflate => {
                 let inflater = flate2::read::DeflateDecoder::new(ent.reader());
-                let mut verifier = ent.verifier(inflater);
+                let mut verifier = ent.verifying_reader(inflater);
                 let mut data = Vec::new();
                 std::io::copy(&mut verifier, &mut Cursor::new(&mut data)).unwrap();
                 actual.push(TestZip {


### PR DESCRIPTION
Allow one to consume the reader and have it spit out a verifier for the claim by reading the data descriptor. Make it easier for the use case where the IO is separated from the inflation.