### PR TITLE
Zip locator failures allow file recovery

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -177,7 +177,9 @@ impl ZipArchive<()> {
         file: std::fs::File,
         buffer: &mut [u8],
     ) -> Result<ZipArchive<FileReader>, Error> {
-        ZipLocator::new().locate_in_file(file, buffer)
+        ZipLocator::new()
+            .locate_in_file(file, buffer)
+            .map_err(|e| e.into_parts().1)
     }
 
     pub fn from_seekable<R>(
@@ -188,7 +190,9 @@ impl ZipArchive<()> {
         R: Read + Seek,
     {
         let reader = MutexReader::new(reader);
-        ZipLocator::new().locate_in_reader(reader, buffer)
+        ZipLocator::new()
+            .locate_in_reader(reader, buffer)
+            .map_err(|e| e.into_parts().1)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,3 +97,32 @@ impl From<std::io::Error> for ErrorKind {
         ErrorKind::IO(err)
     }
 }
+
+/// An error that can return ownership of the reader
+#[derive(Debug)]
+pub struct ReaderError<R> {
+    reader: R,
+    error: Error,
+}
+
+impl<R> ReaderError<R> {
+    pub(crate) fn new(reader: R, error: Error) -> ReaderError<R> {
+        ReaderError { reader, error }
+    }
+
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    pub fn into_parts(self) -> (R, Error) {
+        (self.reader, self.error)
+    }
+}
+
+impl<R> std::error::Error for ReaderError<R> where R: std::fmt::Debug {}
+
+impl<R> std::fmt::Display for ReaderError<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}

--- a/src/reader_at.rs
+++ b/src/reader_at.rs
@@ -118,6 +118,15 @@ pub struct FileReader(MutexReader<std::fs::File>);
 #[cfg(unix)]
 pub struct FileReader(std::fs::File);
 
+impl FileReader {
+    pub fn into_inner(self) -> std::fs::File {
+        #[cfg(not(unix))]
+        return self.0.into_inner();
+        #[cfg(unix)]
+        return self.0;
+    }
+}
+
 impl ReaderAt for FileReader {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
         self.0.read_at(buf, offset)
@@ -147,6 +156,10 @@ pub struct MutexReader<R>(std::sync::Mutex<R>);
 impl<R> MutexReader<R> {
     pub fn new(inner: R) -> Self {
         Self(std::sync::Mutex::new(inner))
+    }
+
+    pub fn into_inner(self) -> R {
+        self.0.into_inner().unwrap()
     }
 }
 


### PR DESCRIPTION
When the zip locator fails to find a zip within a file, it now returns an error that contains the file object to transfer ownership back to the caller. This way the caller can continue processing the file.