### PR TITLE
Don't read entry size in slice entries

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -68,10 +68,10 @@ impl<'a> ZipSliceArchive<'a> {
             .get(variable_length..)
             .ok_or(Error::from(ErrorKind::Eof))?;
 
-        let (data, rest) = if rest.len() < file_header.compressed_size as usize {
+        let (data, rest) = if rest.len() < entry.compressed_size_hint() as usize {
             return Err(Error::from(ErrorKind::Eof));
         } else {
-            rest.split_at(file_header.compressed_size as usize)
+            rest.split_at(entry.compressed_size_hint() as usize)
         };
 
         let expected_crc = if entry.has_data_descriptor {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -329,7 +329,7 @@ impl<'a, W> ZipEntryWriter<'a, W> {
         self.compressed_bytes
     }
 
-    pub fn finish(self, mut output: DataDescriptorOutput) -> Result<(), Error>
+    pub fn finish(self, mut output: DataDescriptorOutput) -> Result<u64, Error>
     where
         W: Write,
     {
@@ -380,7 +380,7 @@ impl<'a, W> ZipEntryWriter<'a, W> {
             crc: output.crc,
         });
 
-        Ok(())
+        Ok(self.compressed_bytes)
     }
 }
 
@@ -458,11 +458,21 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DataDescriptorOutput {
     crc: u32,
     compressed_size: u64,
     uncompressed_size: u64,
+}
+
+impl DataDescriptorOutput {
+    pub fn crc(&self) -> u32 {
+        self.crc
+    }
+
+    pub fn uncompressed_size(&self) -> u64 {
+        self.uncompressed_size
+    }
 }
 
 #[derive(Debug)]
@@ -483,7 +493,7 @@ pub struct ZipEntryOptions {
 impl Default for ZipEntryOptions {
     fn default() -> Self {
         ZipEntryOptions {
-            compression_method: CompressionMethod::Deflate,
+            compression_method: CompressionMethod::Store,
         }
     }
 }


### PR DESCRIPTION
The source of truth is the central directory. When writing, these headers will often be zeroed out with the data descriptor preferred.