### PR TITLE
Rename ZipSlice::into_owned -> into_reader

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -50,7 +50,11 @@ impl<'a> ZipSliceArchive<'a> {
         self.eocd.base_offset()
     }
 
-    pub fn into_owned(self) -> ZipArchive<&'a [u8]> {
+    /// Convert the slice archive into a general archive.
+    ///
+    /// This is useful for downstream libraries who don't want to expose a bunch
+    /// of methods and structs specialized for byte slices.
+    pub fn into_reader(self) -> ZipArchive<&'a [u8]> {
         ZipArchive {
             reader: self.data,
             comment: self.comment.into_owned(),


### PR DESCRIPTION
into_owned would imply that the underlying data becomes owned (ie: convert byte slice into vec), this makes it a bit clearer that the returned Archive works over a reader.