### PR TITLE
Rename RawZipWriter to ZipDataWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ let mut file = archive.new_file("file.txt", options)?;
 // Wrap the file in a deflate compressor.
 let mut encoder = flate2::write::DeflateEncoder::new(&mut file, flate2::Compression::default());
 
-// Wrap the compressor in a RawZipWriter, which will track information for the
+// Wrap the compressor in a data writer, which will track information for the
 // Zip data descriptor (like uncompressed size and crc).
-let mut writer = rawzip::RawZipWriter::new(encoder);
+let mut writer = rawzip::ZipDataWriter::new(encoder);
 
 // Copy the data to the writer.
 std::io::copy(&mut &data[..], &mut writer)?;

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -11,7 +11,7 @@ fn main() {
     let output = {
         let mut encoder =
             flate2::write::DeflateEncoder::new(&mut file, flate2::Compression::default());
-        let mut writer = rawzip::RawZipWriter::new(&mut encoder);
+        let mut writer = rawzip::ZipDataWriter::new(&mut encoder);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, output) = writer.finish().unwrap();
         output

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -101,7 +101,7 @@ fn test_read_what_we_write_slice(data: Vec<u8>) {
         let mut file = archive
             .new_file("file.txt", rawzip::ZipEntryOptions::default())
             .unwrap();
-        let mut writer = rawzip::RawZipWriter::new(&mut file);
+        let mut writer = rawzip::ZipDataWriter::new(&mut file);
         std::io::copy(&mut Cursor::new(&data), &mut writer).unwrap();
         let (_, descriptor) = writer.finish().unwrap();
         assert_eq!(descriptor.uncompressed_size(), data.len() as u64);


### PR DESCRIPTION
The name seems more fitting. Also removed some getters that would only be misleading.