### PR TITLE
Add `as_bytes` for ZipSliceArchive

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -37,6 +37,13 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
         }
     }
 
+    /// Returns the byte slice that represents the zip file.
+    ///
+    /// This will include the entire input slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
     pub fn entries_hint(&self) -> u64 {
         self.eocd.entries()
     }


### PR DESCRIPTION
This will allow one to access any prelude data when ZipSliceArchive is over a Vec<u8>.