### PR TITLE
Allow ZipLocator to return slice ownership back in error

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -205,7 +205,7 @@ impl ZipArchive<()> {
     }
 
     pub fn from_slice<T: AsRef<[u8]>>(data: T) -> Result<ZipSliceArchive<T>, Error> {
-        ZipLocator::new().locate_in_slice(data)
+        ZipLocator::new().locate_in_slice(data).map_err(|(_, e)| e)
     }
 
     pub fn from_file(
@@ -214,7 +214,7 @@ impl ZipArchive<()> {
     ) -> Result<ZipArchive<FileReader>, Error> {
         ZipLocator::new()
             .locate_in_file(file, buffer)
-            .map_err(|e| e.into_parts().1)
+            .map_err(|(_, e)| e)
     }
 
     pub fn from_seekable<R>(
@@ -227,7 +227,7 @@ impl ZipArchive<()> {
         let reader = MutexReader::new(reader);
         ZipLocator::new()
             .locate_in_reader(reader, buffer)
-            .map_err(|e| e.into_parts().1)
+            .map_err(|(_, e)| e)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -101,32 +101,3 @@ impl From<std::io::Error> for ErrorKind {
         ErrorKind::IO(err)
     }
 }
-
-/// An error that can return ownership of the reader
-#[derive(Debug)]
-pub struct ReaderError<R> {
-    reader: R,
-    error: Error,
-}
-
-impl<R> ReaderError<R> {
-    pub(crate) fn new(reader: R, error: Error) -> ReaderError<R> {
-        ReaderError { reader, error }
-    }
-
-    pub fn into_inner(self) -> R {
-        self.reader
-    }
-
-    pub fn into_parts(self) -> (R, Error) {
-        (self.reader, self.error)
-    }
-}
-
-impl<R> std::error::Error for ReaderError<R> where R: std::fmt::Debug {}
-
-impl<R> std::fmt::Display for ReaderError<R> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.error)
-    }
-}


### PR DESCRIPTION
When parsing a zip from a vec, it would be nice to return the vec to the caller on error so that they may continue processing the vec (ie: try and detect if the data represents a zip and if not, do something else).

This commit also removes the `ReaderError` and instead uses a tuple. I'm not sure if this is the right approach, but at least this is what reddit thinks :p

https://www.reddit.com/r/rust/comments/n4puxb/function_that_takes_ownership_and_returns_result/