### PR TITLE
Consistent behavior between archives when reading truncated zip comments

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1454,4 +1454,18 @@ mod tests {
         let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buf);
         assert!(archive.is_err());
     }
+
+    #[test]
+    pub fn trunc_comment_zips() {
+        let data = [
+            80, 75, 6, 7, 21, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 10, 0, 59, 59, 80, 75, 5, 6, 0,
+            255, 255, 255, 255, 255, 255, 0, 0, 0, 80, 75, 6, 6, 0, 0, 0, 10,
+        ];
+        let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+        let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buf);
+        assert!(archive.is_err());
+
+        let archive = ZipArchive::from_slice(data);
+        assert!(archive.is_err());
+    }
 }

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -149,13 +149,12 @@ impl ZipLocator {
         if end_of_central_directory.len() < comment_len {
             comment[..end_of_central_directory.len()].copy_from_slice(end_of_central_directory);
             let pos = end_of_central_directory.len();
-            let read = reader.read_at_most_at(
+            let result = reader.read_exact_at(
                 &mut comment[pos..],
-                comment_len - pos,
                 stream_pos + EndOfCentralDirectoryRecordFixed::SIZE as u64 + pos as u64,
             );
 
-            if let Err(e) = read {
+            if let Err(e) = result {
                 return Err((reader.inner, Error::io(e)));
             }
         } else {

--- a/src/reader_at.rs
+++ b/src/reader_at.rs
@@ -45,13 +45,6 @@ pub(crate) trait ReaderAtExt {
 
     fn read_at_least_at(&self, buffer: &mut [u8], size: usize, offset: u64)
         -> Result<usize, Error>;
-
-    fn read_at_most_at(
-        &self,
-        buffer: &mut [u8],
-        size: usize,
-        offset: u64,
-    ) -> std::io::Result<usize>;
 }
 
 impl<T: ReaderAt> ReaderAtExt for T {
@@ -92,23 +85,6 @@ impl<T: ReaderAt> ReaderAtExt for T {
         }
 
         Ok(read)
-    }
-
-    fn read_at_most_at(
-        &self,
-        buffer: &mut [u8],
-        mut size: usize,
-        offset: u64,
-    ) -> std::io::Result<usize> {
-        size = size.min(buffer.len());
-        let mut pos = 0;
-        while pos < size {
-            match self.read_at(&mut buffer[pos..], offset + pos as u64)? {
-                0 => break,
-                n => pos += n,
-            }
-        }
-        Ok(pos)
     }
 }
 


### PR DESCRIPTION
Slice would return an error and the reader would leave zeroes if not all the comment data was present.