### PR TITLE
Document bad base offset

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -544,6 +544,17 @@ impl EndOfCentralDirectory {
                 let size = u64::from(self.eocd.central_dir_size);
                 let offset = u64::from(self.eocd.central_dir_offset);
                 self.stream_pos.saturating_sub(size).saturating_sub(offset)
+
+                // In the case that the base_offset is calculated to be non-zero
+                // Go's zip reader will check if base_offset of zero would
+                // correspond to a valid directory header and if so, set it to
+                // zero anyways.
+                // https://github.com/golang/go/blob/c0e149b6b1aa2daca64c00804809bc2279e21eee/src/archive/zip/reader.go#L636
+                //
+                // Neither rc-zip or rust's zip crate can handle the file so we
+                // don't either
+                //
+                // See Go's test-badbase.zip and test-baddirsz.zip for test cases
             }
         }
     }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -95,40 +95,6 @@ static ZIP_TEST_CASES: LazyLock<Vec<ZipTestCase>> = LazyLock::new(|| {
             ],
             ..Default::default()
         },
-        // ZipTestCase {
-        //     name: "test-baddirsz.zip",
-        //     comment: Some(b"This is a zipfile comment."),
-        //     files: vec![
-        //         ZipTestFileEntry {
-        //             name: "test.txt",
-        //             expected_content: ExpectedContent::Content(
-        //                 b"This is a test text file.\n".to_vec(),
-        //             ),
-        //         },
-        //         ZipTestFileEntry {
-        //             name: "gophercolor16x16.png",
-        //             expected_content: ExpectedContent::File("gophercolor16x16.png"),
-        //         },
-        //     ],
-        //     ..Default::default()
-        // },
-        // ZipTestCase {
-        //     name: "test-badbase.zip",
-        //     comment: Some(b"This is a zipfile comment."),
-        //     files: vec![
-        //         ZipTestFileEntry {
-        //             name: "test.txt",
-        //             expected_content: ExpectedContent::Content(
-        //                 b"This is a test text file.\n".to_vec(),
-        //             ),
-        //         },
-        //         ZipTestFileEntry {
-        //             name: "gophercolor16x16.png",
-        //             expected_content: ExpectedContent::File("gophercolor16x16.png"),
-        //         },
-        //     ],
-        //     ..Default::default()
-        // },
         ZipTestCase {
             name: "symlink.zip",
             files: vec![ZipTestFileEntry {


### PR DESCRIPTION
Go's zip reader will attempt read at a base offset of 0, and if so, use that value above all else. Very interesting, but I'm not sure how widespread this practice is, so document it for potential future improvements.