### PR TITLE
Implement Rust builder API for ZIP archive writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ let data = b"Hello, world!";
 let mut output = Vec::new();
 let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
 
-// Declare that we'll be compressing the data with the deflate compression method.
-let options = rawzip::ZipEntryOptions::default().compression_method(rawzip::CompressionMethod::Deflate);
-
-// Start of a new file in our zip archive.
-let mut file = archive.new_file("file.txt", options)?;
+// Start of a new file in our zip archive with deflate compression.
+let mut file = archive.new_file("file.txt")
+    .compression_method(rawzip::CompressionMethod::Deflate)
+    .create()?;
 
 // Wrap the file in a deflate compressor.
 let mut encoder = flate2::write::DeflateEncoder::new(&mut file, flate2::Compression::default());

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -33,10 +33,11 @@ fn create_test_zip() -> Vec<u8> {
 
     for i in 0..200_000 {
         let filename = format!("file{:06}.txt", i);
-        let options =
-            rawzip::ZipEntryOptions::default().compression_method(rawzip::CompressionMethod::Store);
-
-        let mut file = archive.new_file(&filename, options).unwrap();
+        let mut file = archive
+            .new_file(&filename)
+            .compression_method(rawzip::CompressionMethod::Store)
+            .create()
+            .unwrap();
         let mut writer = rawzip::ZipDataWriter::new(&mut file);
         writer.write_all(b"x").unwrap();
         let (_, descriptor) = writer.finish().unwrap();

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -7,10 +7,11 @@ fn create_test_zip() -> Vec<u8> {
 
     for i in 0..100_000 {
         let filename = format!("file{:06}.txt", i);
-        let options =
-            rawzip::ZipEntryOptions::default().compression_method(rawzip::CompressionMethod::Store);
-
-        let mut file = archive.new_file(&filename, options).unwrap();
+        let mut file = archive
+            .new_file(&filename)
+            .compression_method(rawzip::CompressionMethod::Store)
+            .create()
+            .unwrap();
         let mut writer = rawzip::ZipDataWriter::new(&mut file);
         writer.write_all(b"x").unwrap();
         let (_, descriptor) = writer.finish().unwrap();

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -780,9 +780,7 @@ fn test_read_what_we_write_slice(data: Vec<u8>) {
     let mut output = Vec::new();
     {
         let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
-        let mut file = archive
-            .new_file("file.txt", rawzip::ZipEntryOptions::default())
-            .unwrap();
+        let mut file = archive.new_file("file.txt").create().unwrap();
         let mut writer = rawzip::ZipDataWriter::new(&mut file);
         std::io::copy(&mut Cursor::new(&data), &mut writer).unwrap();
         let (_, descriptor) = writer.finish().unwrap();

--- a/tests/it/permission_tests.rs
+++ b/tests/it/permission_tests.rs
@@ -1,4 +1,4 @@
-use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter, ZipEntryOptions};
+use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter};
 use std::io::Write;
 
 #[test]
@@ -20,9 +20,11 @@ fn test_unix_permissions_roundtrip() {
         {
             let mut archive = ZipArchiveWriter::new(&mut output);
 
-            let options = ZipEntryOptions::default().unix_permissions(permissions);
-
-            let mut file = archive.new_file("test_file.txt", options).unwrap();
+            let mut file = archive
+                .new_file("test_file.txt")
+                .unix_permissions(permissions)
+                .create()
+                .unwrap();
 
             let mut writer = ZipDataWriter::new(&mut file);
             writer.write_all(b"test content").unwrap();
@@ -59,9 +61,11 @@ fn test_directory_permissions_roundtrip() {
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
 
-        let options = ZipEntryOptions::default().unix_permissions(0o040755);
-
-        archive.new_dir("test_dir/", options).unwrap();
+        archive
+            .new_dir("test_dir/")
+            .unix_permissions(0o040755)
+            .create()
+            .unwrap();
         archive.finish().unwrap();
     }
 
@@ -92,9 +96,7 @@ fn test_permissions_without_unix_permissions() {
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
 
-        let options = ZipEntryOptions::default(); // No unix_permissions set
-
-        let mut file = archive.new_file("test_file.txt", options).unwrap();
+        let mut file = archive.new_file("test_file.txt").create().unwrap(); // No unix_permissions set
 
         let mut writer = ZipDataWriter::new(&mut file);
         writer.write_all(b"test content").unwrap();

--- a/tests/it/utf8_tests.rs
+++ b/tests/it/utf8_tests.rs
@@ -1,4 +1,3 @@
-use rawzip::ZipEntryOptions;
 use rstest::rstest;
 use std::io::Write;
 
@@ -19,9 +18,7 @@ fn test_filename_utf8_flag(#[case] filename: &str, #[case] should_have_utf8_flag
     let mut output = Vec::new();
     {
         let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
-        let mut file = archive
-            .new_file(filename, rawzip::ZipEntryOptions::default())
-            .unwrap();
+        let mut file = archive.new_file(filename).create().unwrap();
         let mut writer = rawzip::ZipDataWriter::new(&mut file);
         writer.write_all(b"test content").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
@@ -52,9 +49,7 @@ fn test_directory_utf8_flag(#[case] dirname: &str, #[case] should_have_utf8_flag
     let mut output = Vec::new();
     {
         let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
-        archive
-            .new_dir(dirname, ZipEntryOptions::default())
-            .unwrap();
+        archive.new_dir(dirname).create().unwrap();
         archive.finish().unwrap();
     }
 

--- a/tests/it/zip64_tests.rs
+++ b/tests/it/zip64_tests.rs
@@ -1,6 +1,4 @@
-use rawzip::{
-    ZipArchive, ZipArchiveWriter, ZipDataWriter, ZipEntryOptions, RECOMMENDED_BUFFER_SIZE,
-};
+use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter, RECOMMENDED_BUFFER_SIZE};
 use rstest::rstest;
 use std::io::{Cursor, Write};
 
@@ -53,8 +51,7 @@ fn test_zip64_threshold_entries(#[case] entry_count: usize, #[case] should_be_zi
 
     for i in 0..entry_count {
         let filename = format!("file_{:05}.txt", i);
-        let options = ZipEntryOptions::default();
-        let mut file = archive.new_file(&filename, options).unwrap();
+        let mut file = archive.new_file(&filename).create().unwrap();
         let mut writer = ZipDataWriter::new(&mut file);
         writer.write_all(b"x").unwrap();
         let (_, descriptor_output) = writer.finish().unwrap();


### PR DESCRIPTION
Replace ZipEntryOptions with method-chaining builders for a slightly more type safe API. Previously both files and directories could receive the same zip options, which could result in one specifying a compression method for directories -- and while the code would nullify it before it actually was written, having two separate builders makes the creation more airtight.

This is a breaking change as ZipEntryOptions is no longer public.