### PR TITLE
Allow writing custom or skipping crc values

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -36,15 +36,15 @@ fn create_test_zip() -> Vec<u8> {
 
     for i in 0..200_000 {
         let filename = format!("file{:06}.txt", i);
-        let mut file = archive
+        let (mut entry, config) = archive
             .new_file(&filename)
             .compression_method(rawzip::CompressionMethod::Store)
-            .create()
+            .start()
             .unwrap();
-        let mut writer = rawzip::ZipDataWriter::new(&mut file);
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"x").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
     }
 
     archive.finish().unwrap();
@@ -112,16 +112,16 @@ fn create_zips(c: &mut Criterion) {
                 }
                 filename.push_str(".txt");
 
-                let mut file = archive
+                let (mut entry, config) = archive
                     .new_file(&filename)
                     .compression_method(rawzip::CompressionMethod::Store)
                     .last_modified(utc_timestamp)
-                    .create()
+                    .start()
                     .unwrap();
-                let mut writer = rawzip::ZipDataWriter::new(&mut file);
+                let mut writer = config.wrap(&mut entry);
                 writer.write_all(b"x").unwrap();
                 let (_, descriptor) = writer.finish().unwrap();
-                file.finish(descriptor).unwrap();
+                entry.finish(descriptor).unwrap();
             }
 
             archive.finish().unwrap();

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -11,17 +11,17 @@ fn create_test_zip<const TIMESTAMP: bool>(entries: usize) -> Vec<u8> {
 
     let mut names = NameIter::new();
     for i in 0..entries {
-        let mut file = archive
+        let mut file_builder = archive
             .new_file(names.name_of(i))
             .compression_method(rawzip::CompressionMethod::Store);
         if TIMESTAMP {
-            file = file.last_modified(jan_1_2001);
+            file_builder = file_builder.last_modified(jan_1_2001);
         }
-        let mut file = file.create().unwrap();
-        let mut writer = rawzip::ZipDataWriter::new(&mut file);
+        let (mut entry, config) = file_builder.start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"x").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
     }
 
     archive.finish().unwrap();

--- a/src/time.rs
+++ b/src/time.rs
@@ -52,14 +52,14 @@
 //!
 //!     if !entry.is_dir() {
 //!         // Copy file with preserved modification time
-//!         let mut file = output_archive.new_file(&name)
+//!         let (mut entry, config) = output_archive.new_file(&name)
 //!             .last_modified(utc_time)
-//!             .create()
+//!             .start()
 //!             .unwrap();
-//!         let mut writer = ZipDataWriter::new(&mut file);
+//!         let mut writer = config.wrap(&mut entry);
 //!         writer.write_all(b"example data").unwrap();
 //!         let (_, descriptor) = writer.finish().unwrap();
-//!         file.finish(descriptor).unwrap();
+//!         entry.finish(descriptor).unwrap();
 //!     } else {
 //!         // Copy directory with preserved modification time
 //!         output_archive.new_dir(&name)

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -788,12 +788,12 @@ fn test_read_what_we_write_slice(data: Vec<u8>) {
     let mut output = Vec::new();
     {
         let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
-        let mut file = archive.new_file("file.txt").create().unwrap();
-        let mut writer = rawzip::ZipDataWriter::new(&mut file);
+        let (mut entry, config) = archive.new_file("file.txt").start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         std::io::copy(&mut Cursor::new(&data), &mut writer).unwrap();
         let (_, descriptor) = writer.finish().unwrap();
         assert_eq!(descriptor.uncompressed_size(), data.len() as u64);
-        let compressed = file.finish(descriptor).unwrap();
+        let compressed = entry.finish(descriptor).unwrap();
         assert_eq!(compressed, data.len() as u64);
         archive.finish().unwrap();
     }

--- a/tests/it/modification_time_tests.rs
+++ b/tests/it/modification_time_tests.rs
@@ -1,7 +1,7 @@
 use rawzip::{
     extra_fields::{ExtraFieldId, ExtraFields},
     time::{LocalDateTime, UtcDateTime, ZipDateTimeKind},
-    ZipArchive, ZipArchiveWriter, ZipDataWriter,
+    ZipArchive, ZipArchiveWriter,
 };
 use std::io::Write;
 
@@ -14,15 +14,15 @@ fn test_modification_time_roundtrip_file() {
     // Create archive with modification time
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
-        let mut file = archive
+        let (mut entry, config) = archive
             .new_file("test.txt")
             .last_modified(datetime)
-            .create()
+            .start()
             .unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 
@@ -78,11 +78,11 @@ fn test_no_modification_time_defaults_to_zero() {
     // Create archive without modification time
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
-        let mut file = archive.new_file("test.txt").create().unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let (mut entry, config) = archive.new_file("test.txt").start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 
@@ -112,15 +112,15 @@ fn test_extended_timestamp_format_present() {
     // Create archive with modification time
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
-        let mut file = archive
+        let (mut entry, config) = archive
             .new_file("test.txt")
             .last_modified(datetime)
-            .create()
+            .start()
             .unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 
@@ -143,11 +143,11 @@ fn test_no_extended_timestamp_without_modification_time() {
     // Create archive without modification time
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
-        let mut file = archive.new_file("test.txt").create().unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let (mut entry, config) = archive.new_file("test.txt").start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 
@@ -170,15 +170,15 @@ fn test_timestamp_before_dos_range() {
     // Create archive with pre-1980 timestamp
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
-        let mut file = archive
+        let (mut entry, config) = archive
             .new_file("test.txt")
             .last_modified(datetime)
-            .create()
+            .start()
             .unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 
@@ -207,26 +207,26 @@ fn test_multiple_files_different_timestamps() {
         let mut archive = ZipArchiveWriter::new(&mut output);
 
         // First file
-        let mut file1 = archive
+        let (mut entry1, config1) = archive
             .new_file("file1.txt")
             .last_modified(datetime1)
-            .create()
+            .start()
             .unwrap();
-        let mut writer1 = ZipDataWriter::new(&mut file1);
+        let mut writer1 = config1.wrap(&mut entry1);
         writer1.write_all(b"File 1").unwrap();
         let (_, descriptor1) = writer1.finish().unwrap();
-        file1.finish(descriptor1).unwrap();
+        entry1.finish(descriptor1).unwrap();
 
         // Second file
-        let mut file2 = archive
+        let (mut entry2, config2) = archive
             .new_file("file2.txt")
             .last_modified(datetime2)
-            .create()
+            .start()
             .unwrap();
-        let mut writer2 = ZipDataWriter::new(&mut file2);
+        let mut writer2 = config2.wrap(&mut entry2);
         writer2.write_all(b"File 2").unwrap();
         let (_, descriptor2) = writer2.finish().unwrap();
-        file2.finish(descriptor2).unwrap();
+        entry2.finish(descriptor2).unwrap();
 
         archive.finish().unwrap();
     }

--- a/tests/it/permission_tests.rs
+++ b/tests/it/permission_tests.rs
@@ -1,4 +1,4 @@
-use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter};
+use rawzip::{ZipArchive, ZipArchiveWriter};
 use std::io::Write;
 
 #[test]
@@ -20,16 +20,16 @@ fn test_unix_permissions_roundtrip() {
         {
             let mut archive = ZipArchiveWriter::new(&mut output);
 
-            let mut file = archive
+            let (mut entry, config) = archive
                 .new_file("test_file.txt")
                 .unix_permissions(permissions)
-                .create()
+                .start()
                 .unwrap();
 
-            let mut writer = ZipDataWriter::new(&mut file);
+            let mut writer = config.wrap(&mut entry);
             writer.write_all(b"test content").unwrap();
             let (_, descriptor) = writer.finish().unwrap();
-            file.finish(descriptor).unwrap();
+            entry.finish(descriptor).unwrap();
 
             archive.finish().unwrap();
         }
@@ -96,12 +96,12 @@ fn test_permissions_without_unix_permissions() {
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
 
-        let mut file = archive.new_file("test_file.txt").create().unwrap(); // No unix_permissions set
+        let (mut entry, config) = archive.new_file("test_file.txt").start().unwrap(); // No unix_permissions set
 
-        let mut writer = ZipDataWriter::new(&mut file);
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"test content").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
 
         archive.finish().unwrap();
     }

--- a/tests/it/utf8_tests.rs
+++ b/tests/it/utf8_tests.rs
@@ -18,11 +18,11 @@ fn test_filename_utf8_flag(#[case] filename: &str, #[case] should_have_utf8_flag
     let mut output = Vec::new();
     {
         let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
-        let mut file = archive.new_file(filename).create().unwrap();
-        let mut writer = rawzip::ZipDataWriter::new(&mut file);
+        let (mut entry, config) = archive.new_file(filename).start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"test content").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
-        file.finish(descriptor).unwrap();
+        entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
     }
 

--- a/tests/it/zip64_tests.rs
+++ b/tests/it/zip64_tests.rs
@@ -1,4 +1,4 @@
-use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter, RECOMMENDED_BUFFER_SIZE};
+use rawzip::{ZipArchive, ZipArchiveWriter, RECOMMENDED_BUFFER_SIZE};
 use rstest::rstest;
 use std::io::{Cursor, Write};
 
@@ -53,12 +53,12 @@ fn test_zip64_threshold_entries(#[case] entry_count: usize, #[case] should_be_zi
 
     for i in 0..entry_count {
         let filename = format!("file_{:05}.txt", i);
-        let mut file = archive.new_file(&filename).create().unwrap();
-        let mut writer = ZipDataWriter::new(&mut file);
+        let (mut entry, config) = archive.new_file(&filename).start().unwrap();
+        let mut writer = config.wrap(&mut entry);
         writer.write_all(b"x").unwrap();
         let (_, descriptor_output) = writer.finish().unwrap();
 
-        file.finish(descriptor_output).unwrap();
+        entry.finish(descriptor_output).unwrap();
     }
 
     let writer = archive.finish().unwrap();


### PR DESCRIPTION
`ZipFileBuilder::create()` has been deprecated in favor of `ZipFileBuilder::start()`, which allows propagation of the newly introduced crc32 customization option into the uncompressed data writer, `ZipDataWriter`.

There are three new options for crc32:

- `Calculate`, the default
- `Custom(u32)`, set the value yourself
- `Skip` Bypass crc32 calculation entirely.

Considering `ZipFileBuilder::create()` was the way to write zip files before, instead of a breaking change, it has been deprecated.

The benefit of this new approach is that one no longer needs to rely on discovering `ZipDataWriter` type as it is automatically created through the `wrap` function.

```rust
let mut output = std::io::Cursor::new(Vec::new());
let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
let (mut entry, config) = archive.new_file("file.txt").start().unwrap();
let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
let mut writer = config.wrap(encoder);
writer.write_all(b"Hello").unwrap();
let (encoder, output) = writer.finish().unwrap();
encoder.finish().unwrap();
entry.finish(output).unwrap();
archive.finish().unwrap();
```