### PR TITLE
Add upper bound offset API for zip archive location

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -67,9 +67,9 @@ fn entries(c: &mut Criterion) {
     group.bench_function("reader", |b| {
         let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
         b.iter(|| {
-            let mut cursor = Cursor::new(&zip_data);
+            let cursor = Cursor::new(&zip_data);
             let archive = rawzip::ZipLocator::new()
-                .locate_in_reader(&mut cursor, &mut buffer)
+                .locate_in_reader(cursor, &mut buffer, zip_data.len() as u64)
                 .unwrap();
             let mut total_size = 0u64;
             let mut entries = archive.entries(&mut buffer);

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -304,6 +304,8 @@ impl<'data> Iterator for ZipSliceEntries<'data> {
 ///     Ok(())
 /// }
 /// ```
+///
+/// For more complex use cases, use the [`ZipLocator`] to locate an archive.
 #[derive(Debug, Clone)]
 pub struct ZipArchive<R> {
     pub(crate) reader: R,
@@ -352,15 +354,16 @@ impl ZipArchive<()> {
     /// }
     /// ```
     pub fn from_seekable<R>(
-        reader: R,
+        mut reader: R,
         buffer: &mut [u8],
     ) -> Result<ZipArchive<MutexReader<R>>, Error>
     where
         R: Read + Seek,
     {
+        let end_offset = reader.seek(std::io::SeekFrom::End(0))?;
         let reader = MutexReader::new(reader);
         ZipLocator::new()
-            .locate_in_reader(reader, buffer)
+            .locate_in_reader(reader, buffer, end_offset)
             .map_err(|(_, e)| e)
     }
 }

--- a/tests/it/concatenated_zip_tests.rs
+++ b/tests/it/concatenated_zip_tests.rs
@@ -1,0 +1,68 @@
+use rawzip::{ZipArchive, ZipArchiveWriter, ZipDataWriter};
+use std::io::Write;
+
+/// Test basic concatenated ZIP functionality: two ZIP files with prefix data
+#[test]
+fn test_concatenated_zip_files() {
+    // Create two concatenated ZIP files with prefix data
+    let data = {
+        let mut data = Vec::new();
+
+        // First ZIP with prefix
+        data.extend_from_slice(b"PREFIX_FOR_FIRST_ZIP\n");
+        {
+            let mut archive = ZipArchiveWriter::new(&mut data);
+            let mut file = archive.new_file("first.txt").create().unwrap();
+            let mut writer = ZipDataWriter::new(&mut file);
+            writer.write_all(b"First ZIP content").unwrap();
+            let (_, descriptor) = writer.finish().unwrap();
+            file.finish(descriptor).unwrap();
+            archive.finish().unwrap();
+        }
+
+        // Second ZIP with prefix
+        data.extend_from_slice(b"PREFIX_FOR_SECOND_ZIP\n");
+        {
+            let mut archive = ZipArchiveWriter::new(&mut data);
+            let mut file = archive.new_file("second.txt").create().unwrap();
+            let mut writer = ZipDataWriter::new(&mut file);
+            writer.write_all(b"Second ZIP content").unwrap();
+            let (_, descriptor) = writer.finish().unwrap();
+            file.finish(descriptor).unwrap();
+            archive.finish().unwrap();
+        }
+        data
+    };
+
+    // Start off by reading the zip as one normally does
+    let second_archive = ZipArchive::from_slice(&data).unwrap();
+
+    // Verify that the last concatenated ZIP would be detected first
+    let entries: Vec<_> = second_archive.entries().collect();
+    assert_eq!(entries.len(), 1);
+    let entry = entries[0].as_ref().unwrap();
+    assert_eq!(entry.file_path().as_ref(), b"second.txt");
+
+    // Realize that the base offset is not zero so there is prefix data
+    assert_ne!(second_archive.base_offset(), 0);
+
+    // Attempt to see if there are additional zips in the data. In this test we
+    // could just pass a subset of the slice to the locator
+    // `ZipArchive::from_slice`, but let's emulate what the code would look like
+    // if it was a 100GB file.
+    let locator = rawzip::ZipLocator::new();
+    let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let reader = std::io::Cursor::new(&data);
+    let first_archive = locator
+        .locate_in_reader(reader, &mut buffer, second_archive.base_offset())
+        .unwrap();
+    let first_base_offset = first_archive.base_offset();
+
+    // Verify prefix data extraction
+    let prefix = &data[..first_base_offset as usize];
+    assert_eq!(prefix, b"PREFIX_FOR_FIRST_ZIP\n");
+
+    let mut entries_iter = first_archive.entries(&mut buffer);
+    let entry = entries_iter.next_entry().unwrap().unwrap();
+    assert_eq!(entry.file_path().as_ref(), b"first.txt");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::{Cursor, Write};
 use std::path::Path;
 
+mod concatenated_zip_tests;
 mod modification_time_tests;
 mod permission_tests;
 mod utf8_tests;


### PR DESCRIPTION
Consider these two scenarios:

- A 100 GB file but zip data is only in the first 1GB
- A file that is composed of multiple zip archives concatenated together

Currently zip location always starts the search from the "end" (as defined by seek) of all the data, which either makes zip location slow or cumbersome.

This can be worked around in userland if `FileReader` is wrapped and is written to put a bound on seek. This is awkward.

Since we only use the length calculation from the seek to the end, `ZipLocator::locate_in_reader` has been updated, replacing the `Seek` constraint with an `end_offset` parameter to dictate where to start searching backwards from.

This is a breaking change. To migrate seek implementations:

before
```rust
let archive = locator.locate_in_reader(reader, &mut buffer)
    .map_err(|(_, e)| e)?;
```

After
```rust
let end_offset = reader.seek(std::io::SeekFrom::End(0)).unwrap();
let archive = locator.locate_in_reader(reader, &mut buffer, end_offset)
    .map_err(|(_, e)| e)?;
```

Most should be unaffected by this breaking change as the convenience functions on `ZipArchive` are still present and parsing from a file or byte slice are still the main entrypoints.