### PR TITLE
Expose the end offset of an archive to extract trailing data

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -95,6 +95,15 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
         self.eocd.directory_offset()
     }
 
+    /// Returns the offset where the ZIP archive ends.
+    ///
+    /// See [`ZipArchive::end_offset`] for more details.
+    pub fn end_offset(&self) -> u64 {
+        self.eocd.eocd_offset
+            + EndOfCentralDirectoryRecordFixed::SIZE as u64
+            + self.comment().as_bytes().len() as u64
+    }
+
     /// The comment of the zip file.
     pub fn comment(&self) -> ZipStr {
         let data = self.data.as_ref();
@@ -501,6 +510,25 @@ impl<R> ZipArchive<R> {
     /// [`ZipFileHeaderRecord::local_header_offset`] can be examined.
     pub fn directory_offset(&self) -> u64 {
         self.eocd.directory_offset()
+    }
+
+    /// Returns the offset where the ZIP archive ends.
+    ///
+    /// This returns the position immediately after the last byte of the ZIP
+    /// archive, including the End of Central Directory record and any comment.
+    /// This is useful for extracting trailing data.
+    ///
+    /// The calculation does not rely on any self reported values from the
+    /// archive.
+    ///
+    /// This can be used in conjunction with the starting offset calculation
+    /// start offset as shown in [`RangeReader`] to determine the exact byte
+    /// range (and thus size) of the ZIP archive within a context of a larger
+    /// file.
+    pub fn end_offset(&self) -> u64 {
+        self.eocd.eocd_offset
+            + EndOfCentralDirectoryRecordFixed::SIZE as u64
+            + self.comment().remaining()
     }
 }
 

--- a/tests/it/extra_data_zip_tests.rs
+++ b/tests/it/extra_data_zip_tests.rs
@@ -92,6 +92,11 @@ fn test_concatenated_zip_files() {
     let mut entries_iter = first_archive.entries(&mut buffer);
     let entry = entries_iter.next_entry().unwrap().unwrap();
     assert_eq!(entry.file_path().as_ref(), b"first.txt");
+
+    // Verify that we can also recover the prefix data for the second ZIP
+    let first_archive_end = first_archive.end_offset();
+    let second_prefix = &data[first_archive_end as usize..second_zip_start as usize];
+    assert_eq!(second_prefix, b"PREFIX_FOR_SECOND_ZIP\n");
 }
 
 #[test]


### PR DESCRIPTION
This commit adds `ZipSliceArchive::end_offset` and `ZipArchive::end_offset`, which returns the offset where the ZIP archive ends.

This returns the position immediately after the last byte of the ZIP archive, including the End of Central Directory record and any comment. This is useful for extracting trailing data.

The calculation does not rely on any self reported values from the archive

This can be used in conjunction with starting offset calculation to determine the exact byte range (and thus size) of the ZIP archive within the larger file.

Originally I was going to prefer exposing a "size", but in the context of zip, size can be ambiguous -- does it represent the size if the archive is fully inflated? Or what about the deflated size? Or what about the size of archive and all of internal structures?