### PR TITLE
Add eocd to zip location errors to allow false eocd recovery

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,21 @@ pub struct Error {
 }
 
 impl Error {
+    /// Returns the offset of the end of central directory (EOCD) signature
+    ///
+    /// Useful for reparsing input that contains a false EOCD signature.
+    pub fn eocd_offset(&self) -> Option<u64> {
+        self.inner.eocd_offset
+    }
+
+    /// Sets the false signature offset on this error
+    pub(crate) fn with_eocd_offset(mut self, offset: u64) -> Self {
+        self.inner.eocd_offset = Some(offset);
+        self
+    }
+}
+
+impl Error {
     pub(crate) fn io(err: std::io::Error) -> Error {
         Error::from(ErrorKind::IO(err))
     }
@@ -26,6 +41,7 @@ impl Error {
 #[derive(Debug)]
 struct ErrorInner {
     kind: ErrorKind,
+    eocd_offset: Option<u64>,
 }
 
 /// The kind of error that occurred
@@ -118,7 +134,10 @@ impl std::fmt::Display for ErrorKind {
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
-            inner: Box::new(ErrorInner { kind }),
+            inner: Box::new(ErrorInner {
+                kind,
+                eocd_offset: None,
+            }),
         }
     }
 }

--- a/tests/it/false_signature_tests.rs
+++ b/tests/it/false_signature_tests.rs
@@ -1,0 +1,44 @@
+use rawzip::ZipLocator;
+
+/// Test handling of false EOCD signatures using the slice API
+#[test]
+fn test_false_signature_in_slice() {
+    let mut zip_data = std::fs::read("assets/test.zip").expect("Failed to read test.zip");
+    zip_data.extend_from_slice(b"This some trailing data: ");
+    zip_data.extend_from_slice(&0x06054b50u32.to_le_bytes());
+    zip_data.extend_from_slice(b" oh my!\n");
+
+    let locator = ZipLocator::new();
+    let (_, e) = locator.locate_in_slice(&zip_data).unwrap_err();
+    let offset = e.eocd_offset().unwrap();
+    assert_eq!(offset, 1195);
+
+    // Test that we can locate the real zip
+    let archive = locator
+        .locate_in_slice(&zip_data[..offset.saturating_sub(1) as usize])
+        .unwrap();
+    assert_eq!(archive.comment().as_bytes(), b"This is a zipfile comment.");
+}
+
+/// Test handling of false signatures using the reader API
+#[test]
+fn test_false_signature_in_reader() {
+    let mut zip_data = std::fs::read("assets/test.zip").expect("Failed to read test.zip");
+    zip_data.extend_from_slice(b"This some trailing data: ");
+    zip_data.extend_from_slice(&0x06054b50u32.to_le_bytes());
+    zip_data.extend_from_slice(b" oh my\n");
+
+    let locator = ZipLocator::new();
+    let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let (_, e) = locator
+        .locate_in_reader(&zip_data, &mut buf, zip_data.len() as u64)
+        .unwrap_err();
+    let offset = e.eocd_offset().unwrap();
+    assert_eq!(offset, 1195);
+
+    // Test that we can locate the real zip
+    let archive = locator
+        .locate_in_reader(&zip_data, &mut buf, offset.saturating_sub(1))
+        .unwrap();
+    assert_eq!(archive.comment().as_bytes(), b"This is a zipfile comment.");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -6,6 +6,7 @@ use std::io::{Cursor, Write};
 use std::path::Path;
 
 mod concatenated_zip_tests;
+mod false_signature_tests;
 mod modification_time_tests;
 mod permission_tests;
 mod utf8_tests;


### PR DESCRIPTION
Consider the use case where the zip comment or trailing data contains the same byte sequence as the EOCD signature. This commit includes the offset of the detected of the EOCD in the error so that the user is empowered to start searching for another instance of the signature starting at the incorrect offset via `ZipLocator::locate_In_reader`

This test shows the new functionality pretty well:

```rust
#[test]
fn test_false_signature_in_reader() {
    let mut zip_data = std::fs::read("assets/test.zip").expect("Failed to read test.zip");
    zip_data.extend_from_slice(b"This some trailing data: ");
    zip_data.extend_from_slice(&0x06054b50u32.to_le_bytes());
    zip_data.extend_from_slice(b" oh my\n");

    let locator = ZipLocator::new();
    let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
    let (_, e) = locator
        .locate_in_reader(&zip_data, &mut buf, zip_data.len() as u64)
        .unwrap_err();
    let offset = e.eocd_offset().unwrap();
    assert_eq!(offset, 1195);

    // Test that we can locate the real zip
    let archive = locator
        .locate_in_reader(&zip_data, &mut buf, offset.saturating_sub(1))
        .unwrap();
    assert_eq!(archive.comment().as_bytes(), b"This is a zipfile comment.");
}
```