### PR TITLE
Zero allocation ZipArchive creation with deferred RangeReader

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -19,11 +19,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Archive:  {}", archive_path);
 
-    if !archive.comment().as_bytes().is_empty() {
-        println!(
-            "Comment:  {}",
-            String::from_utf8_lossy(archive.comment().as_bytes())
-        );
+    let mut comment_reader = archive.comment();
+    if comment_reader.remaining() > 0 {
+        print!("Comment: ");
+        std::io::copy(&mut comment_reader, &mut std::io::stdout().lock())?;
+        println!();
     }
 
     println!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,5 @@ pub use crc::crc32;
 pub use errors::{Error, ErrorKind};
 pub use locator::*;
 pub use mode::EntryMode;
-pub use reader_at::{FileReader, ReaderAt};
+pub use reader_at::{FileReader, RangeReader, ReaderAt};
 pub use writer::*;

--- a/src/reader_at.rs
+++ b/src/reader_at.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+use std::ops::Range;
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
 
@@ -221,5 +223,207 @@ impl ReaderAt for Vec<u8> {
     #[inline]
     fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
         self.as_slice().read_at(buf, offset)
+    }
+}
+
+/// A reader that reads a specific range of data from a [`ReaderAt`] source.
+///
+/// `RangeReader` implements [`std::io::Read`] and provides bounded reading
+/// within a specified range of offsets. It maintains its current position and
+/// ensures reads don't exceed the defined end boundary.
+///
+/// Useful when working with APIs that operate on [`std::io::Read`] instead of
+/// [`ReaderAt`]. For instance, incrementally reading large prelude and trailing
+/// data of a ZIP file.
+///
+/// # Examples
+///
+/// Reading prelude data from a zip file:
+///
+/// ```
+/// use std::io::Read;
+/// use rawzip::{ZipArchive, RangeReader, RECOMMENDED_BUFFER_SIZE};
+/// use std::fs::File;
+///
+/// let file = File::open("assets/test-prefix.zip")?;
+/// let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+/// let archive = ZipArchive::from_file(file, &mut buffer)?;
+///
+/// // Typically you only need the first entry to find where the zip data starts
+/// // but this is the longer form that examines every entry in case they are
+/// // out of order
+/// let mut zip_start_offset = archive.directory_offset();
+/// let mut entries = archive.entries(&mut buffer);
+/// while let Some(entry) = entries.next_entry()? {
+///     zip_start_offset = zip_start_offset.min(entry.local_header_offset());
+/// }
+///
+/// // For example purposes, just slurp up all the prelude data
+/// let mut prelude_reader = RangeReader::new(archive.get_ref(), 0..zip_start_offset);
+/// prelude_reader.read_exact(&mut buffer[..zip_start_offset as usize])?;
+/// assert_eq!(
+///     &buffer[..zip_start_offset as usize],
+///     b"prefix that could be an executable jar file"
+/// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct RangeReader<R> {
+    archive: R,
+    offset: u64,
+    end_offset: u64,
+}
+
+impl<R> RangeReader<R> {
+    /// Creates a new `RangeReader` that will read data from the specified range.
+    #[inline]
+    pub fn new(archive: R, range: Range<u64>) -> Self {
+        Self {
+            archive,
+            offset: range.start,
+            end_offset: range.end,
+        }
+    }
+
+    /// Returns the current read position within the range.
+    #[inline]
+    pub fn position(&self) -> u64 {
+        self.offset
+    }
+
+    /// Returns the remaining bytes that are expected to be read from the
+    /// current position.
+    ///
+    /// When a range reader is constructed with a range that exceeds the
+    /// underlying reader, remaining will be non-zero when `read()` returns zero
+    /// signalling the end of the stream.
+    #[inline]
+    pub fn remaining(&self) -> u64 {
+        self.end_offset - self.offset
+    }
+
+    /// Returns the end offset of the range.
+    #[inline]
+    pub fn end_offset(&self) -> u64 {
+        self.end_offset
+    }
+
+    /// Returns a reference to the underlying reader.
+    #[inline]
+    pub fn get_ref(&self) -> &R {
+        &self.archive
+    }
+
+    /// Consumes the self and returns the underlying reader.
+    #[inline]
+    pub fn into_inner(self) -> R {
+        self.archive
+    }
+}
+
+impl<R> Read for RangeReader<R>
+where
+    R: ReaderAt,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read_size = buf.len().min(self.remaining() as usize);
+        let read = self.archive.read_at(&mut buf[..read_size], self.offset)?;
+        self.offset += read as u64;
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn test_range_reader_basic() {
+        let data = b"Hello, World! This is test data.";
+        let mut range_reader = RangeReader::new(data.as_slice(), 7..13);
+
+        let mut buffer = [0u8; 10];
+        let bytes_read = range_reader.read(&mut buffer).unwrap();
+
+        assert_eq!(bytes_read, 6);
+        assert_eq!(&buffer[..bytes_read], b"World!");
+    }
+
+    #[test]
+    fn test_range_reader_multiple_reads() {
+        let data = b"0123456789";
+        let mut range_reader = RangeReader::new(data.as_slice(), 2..8);
+
+        let mut buffer = [0u8; 3];
+        let bytes_read1 = range_reader.read(&mut buffer).unwrap();
+        assert_eq!(bytes_read1, 3);
+        assert_eq!(&buffer[..bytes_read1], b"234");
+        assert_eq!(range_reader.position(), 5);
+
+        let bytes_read2 = range_reader.read(&mut buffer).unwrap();
+        assert_eq!(bytes_read2, 3);
+        assert_eq!(&buffer[..bytes_read2], b"567");
+        assert_eq!(range_reader.position(), 8);
+
+        // Should return 0 when at end
+        let bytes_read3 = range_reader.read(&mut buffer).unwrap();
+        assert_eq!(bytes_read3, 0);
+    }
+
+    #[test]
+    fn test_range_reader_empty_range() {
+        let data = b"Hello, World!";
+        let mut range_reader = RangeReader::new(data.as_slice(), 5..5);
+
+        let mut buffer = [0u8; 10];
+        let bytes_read = range_reader.read(&mut buffer).unwrap();
+
+        assert_eq!(bytes_read, 0);
+        assert_eq!(range_reader.remaining(), 0);
+    }
+
+    #[test]
+    fn test_range_reader_get_ref_and_into_inner() {
+        let data = b"Hello, World!";
+        let range_reader = RangeReader::new(data.as_slice(), 0..5);
+
+        assert_eq!(range_reader.get_ref(), &data.as_slice());
+        let inner = range_reader.into_inner();
+        assert_eq!(inner, data.as_slice());
+    }
+
+    #[test]
+    fn test_range_reader_clone() {
+        let data = b"Hello, World!";
+        let range_reader = RangeReader::new(data.as_slice(), 0..5);
+        let cloned = range_reader.clone();
+
+        assert_eq!(range_reader.position(), cloned.position());
+        assert_eq!(range_reader.remaining(), cloned.remaining());
+    }
+
+    #[test]
+    fn test_range_reader_range_exceeds_data() {
+        let data = b"Hello";
+
+        // Test range that starts within data but extends beyond
+        let mut reader1 = RangeReader::new(data.as_slice(), 3..10);
+        let mut buf1 = [0u8; 10];
+        let read1 = reader1.read(&mut buf1).unwrap();
+        assert_eq!(read1, 2); // Only reads "lo"
+        assert_eq!(&buf1[..read1], b"lo");
+
+        // Test range that starts at end of data
+        let mut reader2 = RangeReader::new(data.as_slice(), 5..10);
+        let mut buf2 = [0u8; 10];
+        let read2 = reader2.read(&mut buf2).unwrap();
+        assert_eq!(read2, 0); // No data to read
+
+        // Test range that starts beyond data
+        let mut reader3 = RangeReader::new(data.as_slice(), 10..20);
+        let mut buf3 = [0u8; 10];
+        let read3 = reader3.read(&mut buf3).unwrap();
+        assert_eq!(read3, 0); // No data to read
     }
 }

--- a/tests/it/false_signature_tests.rs
+++ b/tests/it/false_signature_tests.rs
@@ -1,4 +1,5 @@
 use rawzip::{ZipArchive, ZipLocator};
+use std::io::Read;
 
 /// Test handling of false EOCD signatures using the slice API
 #[test]
@@ -40,7 +41,11 @@ fn test_false_signature_in_reader() {
     let archive = locator
         .locate_in_reader(&zip_data, &mut buf, offset.saturating_sub(1))
         .unwrap();
-    assert_eq!(archive.comment().as_bytes(), b"This is a zipfile comment.");
+    let mut comment_reader = archive.comment();
+    let comment_len = comment_reader.remaining() as usize;
+    let mut comment_buffer = vec![0u8; comment_len];
+    comment_reader.read_exact(&mut comment_buffer).unwrap();
+    assert_eq!(comment_buffer.as_slice(), b"This is a zipfile comment.");
 }
 
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,7 +3,7 @@ use rawzip::extra_fields::ExtraFieldId;
 use rawzip::time::{LocalDateTime, UtcDateTime, ZipDateTimeKind};
 use rawzip::{Error, ErrorKind, ZipArchive};
 use std::fs::File;
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 use std::path::Path;
 
 mod extra_data_zip_tests;
@@ -442,8 +442,12 @@ fn process_archive_files<R: rawzip::ReaderAt>(
     buf: &mut [u8],
 ) -> Result<(), Error> {
     if let Some(expected_comment_bytes) = case.comment {
+        let mut comment_reader = archive.comment();
+        let comment_len = comment_reader.remaining() as usize;
+        let mut comment_buffer = vec![0u8; comment_len];
+        comment_reader.read_exact(&mut comment_buffer).unwrap();
         assert_eq!(
-            archive.comment().as_bytes(),
+            comment_buffer.as_slice(),
             expected_comment_bytes,
             "Comment mismatch for {}",
             case.name


### PR DESCRIPTION
The allocation of the ZipArchive's comment strikes me as antithetical with the rest of the crate that tries to surface abstractions that allows users to avoid heap allocations and in general, follow don't pay for what you don't use philosophy.

This is a breaking change, `ZipArchive::comment()` now returns the newly introduced `RangeReader<&R>` instead of `ZipString`, which exposes a `Read` interface between offsets for users to read the zip comment into a user provided buffer. A `RangeReader` is also useful abstraction for incrementally reading a potentially large prelude in a zip file.

This commit enforces consistency in the slice archive and reader archive that both validate enough data for the comment is present prior to returning the created archive. There is room in the future for making this configurable

With these changes, there are zero allocations along the happy path for ZipArchive creation.