### PR TITLE
Allow archive writer creation with initial capacity

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -29,7 +29,9 @@ fn eocd(c: &mut Criterion) {
 
 fn create_test_zip() -> Vec<u8> {
     let mut output = Cursor::new(Vec::new());
-    let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
+    let mut archive = rawzip::ZipArchiveWriter::builder()
+        .with_capacity(200_000)
+        .build(&mut output);
 
     for i in 0..200_000 {
         let filename = format!("file{:06}.txt", i);

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -3,7 +3,9 @@ use std::io::{Cursor, Write};
 
 fn create_test_zip() -> Vec<u8> {
     let mut output = Cursor::new(Vec::new());
-    let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
+    let mut archive = rawzip::ZipArchiveWriter::builder()
+        .with_capacity(100_000)
+        .build(&mut output);
 
     for i in 0..100_000 {
         let filename = format!("file{:06}.txt", i);

--- a/tests/it/extra_data_zip_tests.rs
+++ b/tests/it/extra_data_zip_tests.rs
@@ -144,7 +144,10 @@ fn test_zip_with_secret_prelude() {
 fn test_zip_declared_prelude(#[case] entry_count: usize) {
     let mut output = Cursor::new(Vec::new());
     output.write_all(&[0u8; 1000]).unwrap();
-    let mut archive = rawzip::ZipArchiveWriter::at_offset(output.position()).build(output);
+    let mut archive = rawzip::ZipArchiveWriter::builder()
+        .with_offset(output.position())
+        .with_capacity(entry_count)
+        .build(output);
 
     for i in 0..entry_count {
         let filename = format!("file_{:05}.txt", i);

--- a/tests/it/zip64_tests.rs
+++ b/tests/it/zip64_tests.rs
@@ -47,7 +47,9 @@ fn verify_expected_entries(data: &[u8], expected_count: u64) {
 #[case(65536, true)]
 fn test_zip64_threshold_entries(#[case] entry_count: usize, #[case] should_be_zip64: bool) {
     let output = Cursor::new(Vec::new());
-    let mut archive = ZipArchiveWriter::new(output);
+    let mut archive = ZipArchiveWriter::builder()
+        .with_capacity(entry_count)
+        .build(output);
 
     for i in 0..entry_count {
         let filename = format!("file_{:05}.txt", i);


### PR DESCRIPTION
- Add `with_capacity(usize)` method on `ZipArchiveWriterBuilder` to pre-allocate Vec for anticipated file count
- *Breaking Change*: Removal of `ZipArchiveWriter::at_offset()`. Migrate to `ZipArchiveWriter::builder().with_offset()`