### PR TITLE
Add ZipSliceArchive::into_zip_archive

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -117,9 +117,22 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
     ///
     /// This is useful for unifying code that might handle both slice-based
     /// and reader-based archives.
+    #[deprecated(note = "Use `ZipSliceArchive::into_zip_archive` instead")]
     pub fn into_reader(self) -> ZipArchive<T> {
         ZipArchive {
             reader: self.data,
+            eocd: self.eocd,
+        }
+    }
+
+    /// Converts the [`ZipSliceArchive`] into a general [`ZipArchive`].
+    ///
+    /// This is useful for unifying code that might handle both slice-based and
+    /// reader-based archives. The data is wrapped in a [`std::io::Cursor`] to
+    /// provide the [`ReaderAt`] implementation needed for [`ZipArchive`].
+    pub fn into_zip_archive(self) -> ZipArchive<std::io::Cursor<T>> {
+        ZipArchive {
+            reader: std::io::Cursor::new(self.data),
             eocd: self.eocd,
         }
     }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -824,7 +824,38 @@ fn zip_integration_tests_vec() {
     let data = std::fs::read("assets/zip64.zip").unwrap();
     let archive = rawzip::ZipArchive::from_slice(data).unwrap();
     assert_eq!(archive.comment().as_bytes(), b"");
-    let reader = archive.into_reader();
+    let reader = archive.into_zip_archive();
+    let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let mut entries = reader.entries(&mut buf);
+    let mut count = 0;
+    while let Some(entry) = entries.next_entry().unwrap() {
+        if entry.is_dir() {
+            continue;
+        }
+        count += 1;
+    }
+    assert_eq!(count, 1);
+}
+
+/// This test is to ensure that the ZipArchive can be created from a custom type
+/// that implements AsRef but not ReaderAt.
+#[test]
+fn zip_integration_test_custom_as_ref() {
+    struct MyBuffer {
+        data: Vec<u8>,
+    }
+
+    impl AsRef<[u8]> for MyBuffer {
+        fn as_ref(&self) -> &[u8] {
+            &self.data
+        }
+    }
+
+    let data = std::fs::read("assets/zip64.zip").unwrap();
+    let my_buffer = MyBuffer { data };
+    let archive = rawzip::ZipArchive::from_slice(&my_buffer).unwrap();
+    assert_eq!(archive.comment().as_bytes(), b"");
+    let reader = archive.into_zip_archive();
     let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let mut entries = reader.entries(&mut buf);
     let mut count = 0;


### PR DESCRIPTION
For types that implement AsRef<[u8]> but not ReaderAt, the
`ZipSliceArchive::into_reader` method has dubious benefits as many
methods on `ZipArchive` require a `ReaderAt` (like calling `entries`).

This is why `into_reader` has been deprecated in favor of a new method:
`into_zip_archive` which guarantees a `ReaderAt` implementation. It does
require wrapping the reader in a Cursor, which doesn't feel great, but
better than a custom type.