### PR TITLE
Rationalize ZipSliceArchive to ZipArchive conversions

### DIFF
--- a/bench/src/shared.rs
+++ b/bench/src/shared.rs
@@ -78,7 +78,7 @@ pub fn setup_reader_entries_fixture(entry_count: usize) -> ReaderEntriesFixture 
     let zip_data = create_test_zip(entry_count);
     let archive = rawzip::ZipArchive::from_slice(zip_data)
         .unwrap()
-        .into_zip_archive();
+        .into_cursor_archive();
 
     ReaderEntriesFixture {
         archive,

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -113,24 +113,17 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
         ZipStr::new(&data[comment_start..comment_start + comment_len])
     }
 
-    /// Converts the [`ZipSliceArchive`] into a general [`ZipArchive`].
-    ///
-    /// This is useful for unifying code that might handle both slice-based
-    /// and reader-based archives.
-    #[deprecated(note = "Use `ZipSliceArchive::into_zip_archive` instead")]
-    pub fn into_reader(self) -> ZipArchive<T> {
-        ZipArchive {
-            reader: self.data,
-            eocd: self.eocd,
-        }
-    }
-
-    /// Converts the [`ZipSliceArchive`] into a general [`ZipArchive`].
+    /// Converts the [`ZipSliceArchive`] into a general [`ZipArchive`] by
+    /// wrapping the data in a [`std::io::Cursor`].
     ///
     /// This is useful for unifying code that might handle both slice-based and
     /// reader-based archives. The data is wrapped in a [`std::io::Cursor`] to
     /// provide the [`ReaderAt`] implementation needed for [`ZipArchive`].
-    pub fn into_zip_archive(self) -> ZipArchive<std::io::Cursor<T>> {
+    ///
+    /// This is only needed for `AsRef<[u8]>` types that do not themselves
+    /// implement [`ReaderAt`], such as a memory-mapped file (`memmap2::Mmap`).
+    /// Otherwise prefer the zero-cost [`ZipSliceArchive::into_reader`].
+    pub fn into_cursor_archive(self) -> ZipArchive<std::io::Cursor<T>> {
         ZipArchive {
             reader: std::io::Cursor::new(self.data),
             eocd: self.eocd,
@@ -603,6 +596,29 @@ where
             body_offset,
             body_end_offset,
         })
+    }
+}
+
+impl<T: ReaderAt> ZipSliceArchive<T> {
+    /// Converts the [`ZipSliceArchive`] into a general [`ZipArchive`].
+    ///
+    /// This is useful for unifying code that might handle both slice-based and
+    /// reader-based archives. Because the underlying data already implements
+    /// [`ReaderAt`], the conversion is zero-cost.
+    pub fn into_reader(self) -> ZipArchive<T> {
+        ZipArchive::from(self)
+    }
+}
+
+impl<R> From<ZipSliceArchive<R>> for ZipArchive<R>
+where
+    R: ReaderAt,
+{
+    fn from(slice_archive: ZipSliceArchive<R>) -> Self {
+        ZipArchive {
+            reader: slice_archive.data,
+            eocd: slice_archive.eocd,
+        }
     }
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -881,9 +881,20 @@ fn catch_incorrect_crc_without_data_descriptor() {
 #[test]
 fn zip_integration_tests_vec() {
     let data = std::fs::read("assets/zip64.zip").unwrap();
-    let archive = rawzip::ZipArchive::from_slice(data).unwrap();
+
+    // `Vec<u8>` implements `ReaderAt`, so it can be converted directly without a
+    // `Cursor` wrapper, both via `into_reader` and the `From`/`Into` impls.
+    let archive = rawzip::ZipArchive::from_slice(data.clone()).unwrap();
     assert_eq!(archive.comment().as_bytes(), b"");
-    let reader = archive.into_zip_archive();
+    let reader: rawzip::ZipArchive<Vec<u8>> = archive.into_reader();
+    assert_entry_count(reader, 1);
+
+    let archive = rawzip::ZipArchive::from_slice(data).unwrap();
+    let reader = rawzip::ZipArchive::from(archive);
+    assert_entry_count(reader, 1);
+}
+
+fn assert_entry_count<R: rawzip::ReaderAt>(reader: rawzip::ZipArchive<R>, expected: usize) {
     let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let mut entries = reader.entries(&mut buf);
     let mut count = 0;
@@ -893,7 +904,7 @@ fn zip_integration_tests_vec() {
         }
         count += 1;
     }
-    assert_eq!(count, 1);
+    assert_eq!(count, expected);
 }
 
 /// This test is to ensure that the ZipArchive can be created from a custom type
@@ -914,7 +925,7 @@ fn zip_integration_test_custom_as_ref() {
     let my_buffer = MyBuffer { data };
     let archive = rawzip::ZipArchive::from_slice(&my_buffer).unwrap();
     assert_eq!(archive.comment().as_bytes(), b"");
-    let reader = archive.into_zip_archive();
+    let reader = archive.into_cursor_archive();
     let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let mut entries = reader.entries(&mut buf);
     let mut count = 0;


### PR DESCRIPTION
- **Un-deprecate `ZipSliceArchive::into_reader`**, now bound to `T: ReaderAt`. Under that bound the resulting `ZipArchive` is always usable, so the original deprecation rationale no longer applies. It's a zero-cost conversion that preserves the concrete type.
- **Add `From<ZipSliceArchive<R>> for ZipArchive<R>`** (where `R: ReaderAt`) as the idiomatic, trait-based equivalent of `into_reader`.
- **Rename `into_zip_archive` -> `into_cursor_archive`** so the `Cursor` wrapping (and its cost) is explicit at the call site. It remains the fallback for `AsRef<[u8]>` types that don't implement `ReaderAt` (e.g. `memmap2::Mmap`, `bytes::Bytes`).
