### PR TITLE
Expose CD comments & add comment writes

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1774,6 +1774,12 @@ impl<'a> ZipFileHeaderRecord<'a> {
     pub fn extra_fields(&self) -> ExtraFields<'_> {
         ExtraFields::new(self.extra_field)
     }
+
+    /// Returns the file entry's comment.
+    #[inline]
+    pub fn comment(&self) -> ZipStr<'_> {
+        self.file_comment
+    }
 }
 
 /// Contains directions to where the Zip entry's data is located within the Zip archive.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -116,6 +116,8 @@ impl ZipArchiveWriterBuilder {
             writer: CountWriter::new(writer, self.count),
             files: Vec::with_capacity(self.capacity),
             file_names: Vec::new(),
+            file_comments: Vec::new(),
+            archive_comment: Vec::new(),
         }
     }
 }
@@ -150,6 +152,8 @@ impl ZipArchiveWriterBuilder {
 pub struct ZipArchiveWriter<W> {
     files: Vec<FileHeader>,
     file_names: Vec<u8>,
+    file_comments: Vec<u8>,
+    archive_comment: Vec<u8>,
     writer: CountWriter<W>,
 }
 
@@ -164,6 +168,16 @@ impl<W> ZipArchiveWriter<W> {
     /// Creates a new `ZipArchiveWriter` that writes to `writer`.
     pub fn new(writer: W) -> Self {
         ZipArchiveWriterBuilder::new().build(writer)
+    }
+
+    /// Sets the archive-level comment.
+    ///
+    /// The comment is written at the end of the archive in the End of Central
+    /// Directory record.
+    ///
+    /// The comment must not exceed 65,535 bytes (validated at finish line).
+    pub fn set_comment(&mut self, comment: impl Into<Vec<u8>>) {
+        self.archive_comment = comment.into();
     }
 
     /// Returns the current offset in the output stream.
@@ -255,6 +269,7 @@ pub struct ZipFileBuilder<'archive, 'name, W> {
     unix_permissions: Option<u32>,
     extra_fields: ExtraFieldsContainer,
     crc32_option: Crc32Option,
+    file_comment: Vec<u8>,
 }
 
 impl<'archive, W> ZipFileBuilder<'archive, '_, W>
@@ -412,6 +427,16 @@ where
         self
     }
 
+    /// Sets a comment for this file entry in the central directory
+    ///
+    /// The comment must not exceed 65,535 bytes. This is validated when the
+    /// entry is created via [`ZipFileBuilder::start`]
+    #[must_use]
+    pub fn comment(mut self, comment: impl Into<Vec<u8>>) -> Self {
+        self.file_comment = comment.into();
+        self
+    }
+
     /// Creates the file entry and returns a writer for the file's content.
     #[deprecated(
         since = "0.4.0",
@@ -465,6 +490,7 @@ where
             modification_time: self.modification_time,
             unix_permissions: self.unix_permissions,
             extra_fields: self.extra_fields,
+            file_comment: self.file_comment,
         };
         let entry_writer = self.archive.new_file_with_options(self.name, options)?;
 
@@ -482,6 +508,7 @@ pub struct ZipDirBuilder<'a, W> {
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
     extra_fields: ExtraFieldsContainer,
+    file_comment: Vec<u8>,
 }
 
 impl<W> ZipDirBuilder<'_, W>
@@ -522,6 +549,16 @@ where
         Ok(self)
     }
 
+    /// Sets a comment for this directory entry.
+    ///
+    /// See [`ZipFileBuilder::comment`] for details. The comment is validated
+    /// when the entry is created via [`ZipDirBuilder::create`].
+    #[must_use]
+    pub fn comment(mut self, comment: impl Into<Vec<u8>>) -> Self {
+        self.file_comment = comment.into();
+        self
+    }
+
     /// Creates the directory entry.
     pub fn create(self) -> Result<(), Error> {
         let options = ZipEntryOptions {
@@ -529,6 +566,7 @@ where
             modification_time: self.modification_time,
             unix_permissions: self.unix_permissions,
             extra_fields: self.extra_fields,
+            file_comment: self.file_comment,
         };
         self.archive.new_dir_with_options(self.name, options)
     }
@@ -610,6 +648,7 @@ where
             modification_time: None,
             unix_permissions: None,
             extra_fields: ExtraFieldsContainer::new(),
+            file_comment: Vec::new(),
         }
     }
 
@@ -647,10 +686,15 @@ where
         let name_len = name_bytes.len() as u16;
         self.file_names.extend_from_slice(name_bytes);
 
+        let file_comment_len = comment_len(&options.file_comment)?;
+
         self.write_local_header(&file_path, flags, CompressionMethod::Store, &mut options)?;
+
+        self.file_comments.extend_from_slice(&options.file_comment);
 
         let file_header = FileHeader {
             name_len,
+            file_comment_len,
             compression_method: CompressionMethod::Store,
             local_header_offset,
             compressed_size: 0,
@@ -694,6 +738,7 @@ where
             unix_permissions: None,
             extra_fields: ExtraFieldsContainer::new(),
             crc32_option: Crc32Option::default(),
+            file_comment: Vec::new(),
         }
     }
 
@@ -724,12 +769,17 @@ where
         let name_len = name_bytes.len() as u16;
         self.file_names.extend_from_slice(name_bytes);
 
+        let file_comment_len = comment_len(&options.file_comment)?;
+
         self.write_local_header(&file_path, flags, options.compression_method, &mut options)?;
+
+        self.file_comments.extend_from_slice(&options.file_comment);
 
         Ok(ZipEntryWriter {
             inner: self,
             compressed_bytes: 0,
             name_len,
+            file_comment_len,
             local_header_offset,
             compression_method: options.compression_method,
             flags,
@@ -747,6 +797,7 @@ where
     where
         W: Write,
     {
+        let archive_comment_len = comment_len(&self.archive_comment)?;
         let central_directory_offset = self.writer.count();
         let total_entries = self.files.len();
 
@@ -756,6 +807,7 @@ where
             || self.files.iter().any(FileHeader::needs_zip64);
 
         let mut name_offset = 0;
+        let mut comment_offset = 0;
 
         // Write central directory entries
         for file in &self.files {
@@ -789,7 +841,7 @@ where
                 uncompressed_size: file.uncompressed_size.min(ZIP64_THRESHOLD_FILE_SIZE) as u32,
                 file_name_len: file.name_len,
                 extra_field_len: file.extra_fields.central_size,
-                file_comment_len: 0,
+                file_comment_len: file.file_comment_len,
                 disk_number_start: 0,
                 internal_file_attrs: 0,
                 external_file_attrs: file.unix_permissions.map(|x| x << 16).unwrap_or(0),
@@ -807,6 +859,13 @@ where
             // Extra fields
             file.extra_fields
                 .write_extra_fields(&mut self.writer, Header::CENTRAL)?;
+
+            if file.file_comment_len > 0 {
+                let new_comment_offset = comment_offset + file.file_comment_len as usize;
+                self.writer
+                    .write_all(&self.file_comments[comment_offset..new_comment_offset])?;
+                comment_offset = new_comment_offset;
+            }
         }
 
         let central_directory_end = self.writer.count();
@@ -847,8 +906,11 @@ where
         let cd_offset = central_directory_offset.min(ZIP64_THRESHOLD_OFFSET) as u32;
         self.writer.write_all(&cd_offset.to_le_bytes())?;
 
-        // Comment length
-        self.writer.write_all(&0u16.to_le_bytes())?;
+        // Comment length and data
+        self.writer.write_all(&archive_comment_len.to_le_bytes())?;
+        if !self.archive_comment.is_empty() {
+            self.writer.write_all(&self.archive_comment)?;
+        }
 
         self.writer.flush()?;
         Ok(self.writer.writer)
@@ -866,6 +928,7 @@ pub struct ZipEntryWriter<'a, W> {
     inner: &'a mut ZipArchiveWriter<W>,
     compressed_bytes: u64,
     name_len: u16,
+    file_comment_len: u16,
     local_header_offset: u64,
     compression_method: CompressionMethod,
     flags: u16,
@@ -930,6 +993,7 @@ impl<'a, W> ZipEntryWriter<'a, W> {
 
         let mut file_header = FileHeader {
             name_len: self.name_len,
+            file_comment_len: self.file_comment_len,
             compression_method: self.compression_method,
             local_header_offset: self.local_header_offset,
             compressed_size: output.compressed_size,
@@ -1079,6 +1143,7 @@ impl DataDescriptorOutput {
 #[derive(Debug)]
 struct FileHeader {
     name_len: u16,
+    file_comment_len: u16,
     compression_method: CompressionMethod,
     local_header_offset: u64,
     compressed_size: u64,
@@ -1119,6 +1184,15 @@ impl FileHeader {
 
         Ok(())
     }
+}
+
+/// Validates that a comment fits within the 16-bit length field
+fn comment_len(comment: &[u8]) -> Result<u16, Error> {
+    u16::try_from(comment.len()).map_err(|_| {
+        Error::from(ErrorKind::InvalidInput {
+            msg: "comment exceeds maximum length of 65,535 bytes".to_string(),
+        })
+    })
 }
 
 /// Writes the ZIP64 End of Central Directory Record
@@ -1191,6 +1265,7 @@ struct ZipEntryOptions {
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
     extra_fields: ExtraFieldsContainer,
+    file_comment: Vec<u8>,
 }
 
 #[cfg(test)]
@@ -1474,6 +1549,74 @@ mod tests {
 
         entry.finish(descriptor).unwrap();
         archive.finish().unwrap();
+    }
+
+    #[test]
+    fn test_comment_round_trip() {
+        use std::io::Write;
+
+        let file_comment = b"hello file comment";
+        let archive_comment = b"hello archive comment";
+
+        let mut output = Cursor::new(Vec::new());
+        let mut archive = ZipArchiveWriter::new(&mut output);
+        archive.set_comment(archive_comment);
+
+        let (mut entry, config) = archive
+            .new_file("file.txt")
+            .comment(file_comment)
+            .start()
+            .unwrap();
+        let mut writer = config.wrap(&mut entry);
+        writer.write_all(b"content").unwrap();
+        let (_, desc) = writer.finish().unwrap();
+        entry.finish(desc).unwrap();
+
+        archive.finish().unwrap();
+
+        let data = output.into_inner();
+        let archive = ZipArchive::from_slice(&data).unwrap();
+
+        // Verify archive comment
+        assert_eq!(archive.comment().as_bytes(), archive_comment);
+
+        // Verify file entry comment
+        let mut entries = archive.entries();
+        let entry = entries.next_entry().unwrap().unwrap();
+        assert_eq!(entry.comment().as_bytes(), file_comment);
+    }
+
+    #[test]
+    fn test_file_comment_too_long_errors_at_start() {
+        let too_long = vec![b'a'; u16::MAX as usize + 1];
+
+        let mut output = Cursor::new(Vec::new());
+        let mut archive = ZipArchiveWriter::new(&mut output);
+
+        let result = archive.new_file("file.txt").comment(too_long).start();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dir_comment_too_long_errors_at_create() {
+        let too_long = vec![b'a'; u16::MAX as usize + 1];
+
+        let mut output = Cursor::new(Vec::new());
+        let mut archive = ZipArchiveWriter::new(&mut output);
+
+        let result = archive.new_dir("dir/").comment(too_long).create();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_archive_comment_too_long_errors_at_finish() {
+        let too_long = vec![b'a'; u16::MAX as usize + 1];
+
+        let mut output = Cursor::new(Vec::new());
+        let mut archive = ZipArchiveWriter::new(&mut output);
+        archive.set_comment(too_long);
+
+        assert!(archive.finish().is_err());
     }
 
     #[test]


### PR DESCRIPTION
Defers validation of the comment data until it actually needs to be written.