### PR TITLE
Defer data descriptor read in verification handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ In its current state, rawzip should not be considered a general purpose Zip libr
 
 - **Bring your own dependencies**: Rawzip pushes the compression responsibility onto the caller. Rust has a myriad of high quality compression libraries to choose from. For instance, just deflate has a half dozen implementations ([#1](https://crates.io/crates/libdeflater), [#2](https://crates.io/crates/miniz_oxide), [#3](https://crates.io/crates/zune-inflate), [#4](https://crates.io/crates/libz-ng-sys), [#5](https://crates.io/crates/zlib-rs), [#6](https://crates.io/crates/cloudflare-zlib-sys)). This allows Rawzip to reach maturity easier and be passively maintained while letting downstream users pick the exact compressor best suited to their needs. The Zip file specification does not change frequently, and the hope is this library won't either.
 
+  The same applies to the CRC: rawzip ships its own (fast) implementation and verifies decompressed data against it by default (see the `verifying_reader` in the example below). But to eke out a bit more performance on platforms that can compute the CRC with hardware intrinsics, you can bring your own and validate it against the archive (see `ZipEntry::claim_verifier`).
+
 ## Features:
 
 - Pure Rust. Zero dependencies. Zero unsafe. Fast.
@@ -93,6 +95,10 @@ std::io::copy(&mut reader, &mut actual)?;
 assert_eq!(&data[..], actual);
 Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+For a more realistic, security-conscious, bring your own CRC zip file extractor that ties the API together, see the [`extract` example][extract-example] (links to GitHub if reading on docs.rs).
+
+[extract-example]: https://github.com/nickbabcock/rawzip/blob/master/examples/extract.rs
 
 ## Security
 

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -6,6 +6,8 @@
 //! - Supports only store, deflate, and zstd compression methods
 //! - Supports only UTF-8 file paths
 
+use std::io::{Read, Write};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 3 {
@@ -183,30 +185,17 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
                 format!("Failed to create output file: {}", out_path.display()),
             )
         })?;
+
         let method = entry.compression_method();
-        match method {
+        let result = match method {
             CompressionMethod::Store => {
-                let mut verifier = zip_entry.verifying_reader(reader);
-                std::io::copy(&mut verifier, &mut outfile).map_err(|e| {
-                    ExtractionError::io_context(
-                        e,
-                        format!(
-                            "Failed to extract uncompressed file: {}",
-                            file_path.as_ref()
-                        ),
-                    )
-                })?;
+                extract(reader, &mut outfile, entry.uncompressed_size_hint())
             }
-            CompressionMethod::Deflate => {
-                let inflater = flate2::read::DeflateDecoder::new(reader);
-                let mut verifier = zip_entry.verifying_reader(inflater);
-                std::io::copy(&mut verifier, &mut outfile).map_err(|e| {
-                    ExtractionError::io_context(
-                        e,
-                        format!("Failed to extract deflated file: {}", file_path.as_ref()),
-                    )
-                })?;
-            }
+            CompressionMethod::Deflate => extract(
+                flate2::read::DeflateDecoder::new(reader),
+                &mut outfile,
+                entry.uncompressed_size_hint(),
+            ),
             CompressionMethod::Zstd | CompressionMethod::ZstdDeprecated => {
                 let decoder = zstd::Decoder::new(reader).map_err(|e| {
                     ExtractionError::io_context(
@@ -217,19 +206,33 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
                         ),
                     )
                 })?;
-                let mut verifier = zip_entry.verifying_reader(decoder);
-                std::io::copy(&mut verifier, &mut outfile).map_err(|e| {
-                    ExtractionError::io_context(
-                        e,
-                        format!("Failed to extract zstd file: {}", file_path.as_ref()),
-                    )
-                })?;
+                extract(decoder, &mut outfile, entry.uncompressed_size_hint())
             }
             _ => {
                 eprintln!("Unsupported compression method {method:?} for file: {file_path:?}");
                 continue;
             }
-        }
+        };
+
+        let actual = result.map_err(|e| {
+            ExtractionError::io_context(
+                e,
+                format!("Failed to extract file: {}", file_path.as_ref()),
+            )
+        })?;
+
+        // Since we brought our own CRC implementation (instead of using
+        // `verifying_reader`), we need to manually ensure the integrity of the
+        // extracted data.
+        zip_entry.claim_verifier().valid(actual).map_err(|e| {
+            ExtractionError::zip_context(
+                e,
+                format!(
+                    "CRC/size verification failed for file: {}",
+                    file_path.as_ref()
+                ),
+            )
+        })?;
 
         match entry.last_modified() {
             rawzip::time::ZipDateTimeKind::Utc(dt) => {
@@ -334,6 +337,28 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
     }
 
     Ok(())
+}
+
+/// Copy the decompressed data into a sink and calculate the verification
+/// payload manually by bringing our own hardware accelerated CRC
+/// implementation.
+///
+/// Reads are capped at one byte past the declared uncompressed size, so a
+/// decompression bomb is written to disk only up to that cap and then surfaces
+/// as an `InvalidSize` error during verification. The cap is `size_hint + 1`
+/// rather than `size_hint`: stopping exactly at the declared size would
+/// silently truncate an oversized stream instead of detecting it.
+fn extract(
+    decompressor: impl Read,
+    mut sink: impl Write,
+    size_hint: u64,
+) -> std::io::Result<rawzip::ZipVerification> {
+    let mut crc_reader = flate2::CrcReader::new(decompressor).take(size_hint.saturating_add(1));
+    let uncompressed_size = std::io::copy(&mut crc_reader, &mut sink)?;
+    Ok(rawzip::ZipVerification {
+        crc: crc_reader.get_ref().crc().sum(),
+        uncompressed_size,
+    })
 }
 
 #[derive(Debug)]

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -141,7 +141,7 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
     ///
     /// See [`ZipArchive::get_entry`] for more details. The biggest difference
     /// between the reader and slice APIs is that the slice APIs will eagerly
-    /// validate that the entire compressed data is present.
+    /// validate that the compressed body is present.
     pub fn get_entry(&self, entry: ZipArchiveEntryWayfinder) -> Result<ZipSliceEntry<'_>, Error> {
         let data = self.data.as_ref();
         let header = &data[(entry.local_header_offset as usize).min(data.len())..];
@@ -156,19 +156,19 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
             return Err(Error::from(ErrorKind::Eof));
         }
 
+        // Split off the data descriptor bytes but don't parse them yet. Parsing
+        // is deferred until the caller resolves the verification handle, so an
+        // mmap-backed slice doesn't fault in the end-of-entry page before the
+        // body has been streamed through.
         let (entire_entry, rest) = header.split_at(total_size as usize);
-
-        let expected_crc = if entry.has_data_descriptor {
-            DataDescriptor::parse(rest)?.crc
-        } else {
-            entry.crc
-        };
 
         Ok(ZipSliceEntry {
             data: entire_entry,
-            verifier: ZipVerification {
-                crc: expected_crc,
+            verification: ZipSliceVerification {
+                descriptor: rest,
+                crc: entry.crc,
                 uncompressed_size: entry.uncompressed_size_hint(),
+                has_data_descriptor: entry.has_data_descriptor,
             },
             local_header_offset: entry.local_header_offset,
             data_start_offset: header_size,
@@ -183,7 +183,7 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
 pub struct ZipSliceEntry<'a> {
     // From local header offset to end of compressed data
     data: &'a [u8],
-    verifier: ZipVerification,
+    verification: ZipSliceVerification<'a>,
     local_header_offset: u64,
     // self.data[self.data_start_offset] is the start of compressed data
     data_start_offset: u32,
@@ -195,26 +195,33 @@ impl<'a> ZipSliceEntry<'a> {
         &self.data[self.data_start_offset as usize..]
     }
 
-    /// Returns a verifier for the CRC and uncompressed size of the entry.
+    /// Returns a deferred verification handle for CRC + size verification
     ///
-    /// Useful when it's more practical to oneshot decompress the data,
-    /// otherwise use [`ZipSliceEntry::verifying_reader`] to stream
-    /// decompression and verification.
-    pub fn claim_verifier(&self) -> ZipVerification {
-        self.verifier
+    /// See [`ZipReader::claim_verifier`] for how to bring your own CRC
+    /// implementation.
+    pub fn claim_verifier(&self) -> ZipSliceVerification<'a> {
+        self.verification
     }
 
     /// Returns a reader that wraps a decompressor and verify the size and CRC
     /// of the decompressed data once finished.
-    pub fn verifying_reader<D>(&self, reader: D) -> ZipSliceVerifier<D>
+    ///
+    /// Verification runs once the decompressed data reaches the declared
+    /// uncompressed size or the wrapped reader is read to EOF (a `read`
+    /// returning `Ok(0)` on a non-empty buffer), whichever comes first.
+    /// Callers that stop reading before either point can call
+    /// [`ZipSliceVerifier::finish`] to surface the incomplete read as an
+    /// error.
+    pub fn verifying_reader<D>(&self, reader: D) -> ZipSliceVerifier<'a, D>
     where
         D: std::io::Read,
     {
         ZipSliceVerifier {
             reader,
-            verifier: self.verifier,
+            expected: self.claim_verifier(),
             crc: 0,
             size: 0,
+            verified: false,
         }
     }
 
@@ -255,40 +262,133 @@ impl<'a> ZipSliceEntry<'a> {
 }
 
 /// Verifies the wrapped reader returns the expected CRC and uncompressed size
+///
+/// Verification (including the lazy data descriptor parse) runs once, when
+/// the decompressed data reaches the declared uncompressed size or the
+/// wrapped reader hits EOF. See [`ZipSliceEntry::verifying_reader`].
 #[derive(Debug, Clone)]
-pub struct ZipSliceVerifier<D> {
+pub struct ZipSliceVerifier<'a, D> {
     reader: D,
     crc: u32,
     size: u64,
-    verifier: ZipVerification,
+    verified: bool,
+    expected: ZipSliceVerification<'a>,
 }
 
-impl<D> ZipSliceVerifier<D> {
-    /// Consumes the `ZipSliceVerifier`, returning the underlying reader.
+impl<'a, D> ZipSliceVerifier<'a, D> {
+    /// Consumes the `ZipSliceVerifier`, returning the underlying reader without
+    /// running verification.
     pub fn into_inner(self) -> D {
         self.reader
     }
+
+    /// Run verification against the bytes read so far and return the inner
+    /// reader.
+    ///
+    /// Verification triggers automatically once the declared uncompressed
+    /// size is reached or EOF is hit; `finish` is for stopping short of
+    /// both, where it surfaces the incomplete read as an error.
+    pub fn finish(mut self) -> Result<D, Error> {
+        self.verify()?;
+        Ok(self.reader)
+    }
+
+    /// Idempotently validate the accumulated CRC/size against the expected
+    /// values, parsing the data descriptor at most once.
+    fn verify(&mut self) -> Result<(), Error> {
+        if !self.verified {
+            self.expected.valid(ZipVerification {
+                crc: self.crc,
+                uncompressed_size: self.size,
+            })?;
+            self.verified = true;
+        }
+        Ok(())
+    }
 }
 
-impl<D> std::io::Read for ZipSliceVerifier<D>
+impl<'a, D> std::io::Read for ZipSliceVerifier<'a, D>
 where
     D: std::io::Read,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // An empty target buffer is not EOF
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         let read = self.reader.read(buf)?;
         self.crc = crc32_chunk(&buf[..read], self.crc);
         self.size += read as u64;
 
-        if read == 0 || self.size >= self.verifier.size() {
-            self.verifier
-                .valid(ZipVerification {
-                    crc: self.crc,
-                    uncompressed_size: self.size,
-                })
+        // Fail oversized streams
+        if self.size > self.expected.uncompressed_size_hint() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                Error::from(ErrorKind::InvalidSize {
+                    expected: self.expected.uncompressed_size_hint(),
+                    actual: self.size,
+                }),
+            ));
+        }
+
+        // Verify once the declared size is reached or at EOF, whichever comes
+        // first, so callers that stop at the known length still get verified.
+        // At size-reached the entry body has been fully streamed, so the data
+        // descriptor read remains deferred until after the body.
+        if read == 0 || self.size >= self.expected.uncompressed_size_hint() {
+            self.verify()
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         }
 
         Ok(read)
+    }
+}
+
+/// A deferred verification handle for a [`ZipSliceEntry`].
+///
+/// Constructing the handle performs no parsing. The expected CRC and
+/// uncompressed size are resolved by [`expected`](Self::expected) /
+/// [`valid`](Self::valid), which parse the data descriptor lazily. This lets
+/// callers stream through the entry body before touching the descriptor bytes
+/// that follow it.
+#[derive(Debug, Clone, Copy)]
+pub struct ZipSliceVerification<'a> {
+    descriptor: &'a [u8],
+    crc: u32,
+    uncompressed_size: u64,
+    has_data_descriptor: bool,
+}
+
+impl<'a> ZipSliceVerification<'a> {
+    /// The expected uncompressed size, as recorded in the central directory.
+    ///
+    /// This is the size rawzip validates against.
+    #[inline]
+    pub fn uncompressed_size_hint(&self) -> u64 {
+        self.uncompressed_size
+    }
+
+    /// Resolve the expected CRC and uncompressed size, parsing the data
+    /// descriptor lazily when present.
+    pub fn expected(&self) -> Result<ZipVerification, Error> {
+        let crc = if self.has_data_descriptor {
+            DataDescriptor::parse(self.descriptor)?.crc
+        } else {
+            self.crc
+        };
+
+        Ok(ZipVerification {
+            crc,
+            uncompressed_size: self.uncompressed_size_hint(),
+        })
+    }
+
+    /// Resolve [`expected`](Self::expected) and compare it against the caller's
+    /// actual CRC/size using the standard policy (a CRC of 0 skips the CRC
+    /// check).
+    pub fn valid(&self, actual: ZipVerification) -> Result<(), Error> {
+        self.expected()?.valid(actual)
     }
 }
 
@@ -630,8 +730,86 @@ where
         }
     }
 
+    /// Returns a deferred handle that verifies the claimed size and checksum of
+    /// this entry's inflated data.
+    ///
+    /// Constructing the handle performs no I/O. The data descriptor (when
+    /// present) is read lazily when validation is performed, so resolve it only
+    /// after all of the entry's data has been read.
+    ///
+    /// # Bring your own CRC
+    ///
+    /// Instead of [`verifying_reader`](ZipEntry::verifying_reader), which uses
+    /// rawzip's CRC implementation, you can compute the checksum yourself (for
+    /// example with a SIMD-accelerated CRC) and validate it against the
+    /// archive. Stream the entry through your own CRC reader and, once you hit
+    /// EOF, hand the result to the deferred handle. Cap reads at one byte past
+    /// the declared uncompressed size so a decompression bomb is detected as
+    /// `InvalidSize` after bounded work instead of being decompressed in full
+    /// (capping at exactly the declared size would silently truncate an
+    /// oversized stream rather than detect it):
+    ///
+    /// ```rust
+    /// # use std::io::Read;
+    /// # // Setup: build an in-memory Zip with one deflated entry and resolve
+    /// # // `zip_entry`. This ceremony is elided to keep the focus on the CRC.
+    /// # let mut output = Vec::new();
+    /// # let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
+    /// # let (mut entry, config) = archive
+    /// #     .new_file("file.txt")
+    /// #     .compression_method(rawzip::CompressionMethod::Deflate)
+    /// #     .start()?;
+    /// # let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
+    /// # let mut writer = config.wrap(encoder);
+    /// # std::io::copy(&mut &b"Hello, world!"[..], &mut writer)?;
+    /// # let (_, descriptor) = writer.finish()?;
+    /// # entry.finish(descriptor)?;
+    /// # archive.finish()?;
+    /// # let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+    /// # let end_offset = output.len() as u64;
+    /// # let archive = rawzip::ZipLocator::new()
+    /// #     .locate_in_reader(output, &mut buf, end_offset)
+    /// #     .map_err(|(_, e)| e)?;
+    /// # let wayfinder = {
+    /// #     let mut entries = archive.entries(&mut buf);
+    /// #     entries.next_entry()?.unwrap().wayfinder()
+    /// # };
+    /// # let zip_entry = archive.get_entry(wayfinder)?;
+    /// // Compute the checksum yourself as the data streams through.
+    /// let verifier = zip_entry.claim_verifier();
+    /// let decompressor = flate2::read::DeflateDecoder::new(zip_entry.reader());
+    /// let mut reader = flate2::CrcReader::new(decompressor)
+    ///     .take(verifier.uncompressed_size_hint().saturating_add(1));
+    /// let uncompressed_size = std::io::copy(&mut reader, &mut std::io::sink())?;
+    ///
+    /// let actual = rawzip::ZipVerification {
+    ///     crc: reader.get_ref().crc().sum(),
+    ///     uncompressed_size,
+    /// };
+    ///
+    /// verifier.valid(actual)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// Alternatively, one can wrap the decode stream, impl [`Read`] and call
+    /// [`valid`](ZipReaderVerification::valid) at EOF.
+    pub fn claim_verifier(&self) -> ZipReaderVerification<&'archive R> {
+        ZipReaderVerification {
+            archive: self.archive.get_ref(),
+            end_offset: self.body_end_offset,
+            crc: self.entry.crc,
+            uncompressed_size: self.entry.uncompressed_size_hint(),
+            has_data_descriptor: self.entry.has_data_descriptor,
+        }
+    }
+
     /// Returns a reader that wraps a decompressor and verify the size and CRC
     /// of the decompressed data once finished.
+    ///
+    /// Verification runs once the decompressed data reaches the declared
+    /// uncompressed size or the wrapped reader is read to EOF, whichever
+    /// comes first. Callers that stop reading before either point can call
+    /// [`ZipVerifier::finish`] to surface the incomplete read as an error.
     pub fn verifying_reader<D>(&self, reader: D) -> ZipVerifier<D, &'archive R>
     where
         D: std::io::Read,
@@ -640,9 +818,8 @@ where
             reader,
             crc: 0,
             size: 0,
-            archive: self.archive.get_ref(),
-            end_offset: self.body_end_offset,
-            wayfinder: self.entry,
+            verified: false,
+            expected: self.claim_verifier(),
         }
     }
 
@@ -817,53 +994,144 @@ impl ZipVerification {
     }
 }
 
-/// Verifies the checksum of the decompressed data matches the checksum listed in the zip
+/// A deferred verification handle for a [`ZipReader`].
+///
+/// Constructing the handle performs no I/O. The expected CRC and uncompressed
+/// size are resolved by [`expected`](Self::expected) / [`valid`](Self::valid),
+/// which read the data descriptor lazily (a positioned read at the end of the
+/// entry body). Deferring that read until the body has been consumed keeps it
+/// within the page-cache / read-ahead window instead of jumping ahead
+/// mid-stream.
 #[derive(Debug, Clone)]
-pub struct ZipVerifier<Decompressor, ReaderAt> {
+pub struct ZipReaderVerification<R> {
+    archive: R,
+    end_offset: u64,
+    crc: u32,
+    uncompressed_size: u64,
+    has_data_descriptor: bool,
+}
+
+impl<R> ZipReaderVerification<R> {
+    /// The expected uncompressed size, as recorded in the central directory.
+    ///
+    /// This is the size rawzip validates against.
+    #[inline]
+    pub fn uncompressed_size_hint(&self) -> u64 {
+        self.uncompressed_size
+    }
+}
+
+impl<R> ZipReaderVerification<R>
+where
+    R: ReaderAt,
+{
+    /// Resolve the expected CRC and uncompressed size, reading the data
+    /// descriptor lazily when present.
+    pub fn expected(&self) -> Result<ZipVerification, Error> {
+        let crc = if self.has_data_descriptor {
+            DataDescriptor::read_at(&self.archive, self.end_offset)?.crc
+        } else {
+            self.crc
+        };
+
+        Ok(ZipVerification {
+            crc,
+            uncompressed_size: self.uncompressed_size_hint(),
+        })
+    }
+
+    /// Resolve [`expected`](Self::expected) and compare it against the caller's
+    /// actual CRC/size using the standard policy (a CRC of 0 skips the CRC
+    /// check).
+    pub fn valid(&self, actual: ZipVerification) -> Result<(), Error> {
+        self.expected()?.valid(actual)
+    }
+}
+
+/// Verifies the checksum of the decompressed data matches the checksum listed in the zip
+///
+/// Verification (including the lazy data descriptor read) runs once, when the
+/// decompressed data reaches the declared uncompressed size or the wrapped
+/// reader hits EOF. See [`ZipEntry::verifying_reader`].
+#[derive(Debug, Clone)]
+pub struct ZipVerifier<Decompressor, R> {
     reader: Decompressor,
     crc: u32,
     size: u64,
-    archive: ReaderAt,
-    end_offset: u64,
-    wayfinder: ZipArchiveEntryWayfinder,
+    verified: bool,
+    expected: ZipReaderVerification<R>,
 }
 
-impl<Decompressor, ReaderAt> ZipVerifier<Decompressor, ReaderAt> {
-    /// Consumes the [`ZipVerifier`], returning the underlying decompressor.
+impl<Decompressor, R> ZipVerifier<Decompressor, R> {
+    /// Consumes the [`ZipVerifier`], returning the underlying decompressor
+    /// without running verification.
     pub fn into_inner(self) -> Decompressor {
         self.reader
     }
 }
 
-impl<Decompressor, Reader> std::io::Read for ZipVerifier<Decompressor, Reader>
+impl<Decompressor, R> ZipVerifier<Decompressor, R>
+where
+    R: ReaderAt,
+{
+    /// Run verification against the bytes read so far and return the inner
+    /// decompressor.
+    ///
+    /// Verification triggers automatically once the declared uncompressed
+    /// size is reached or EOF is hit; `finish` is for stopping short of
+    /// both, where it surfaces the incomplete read as an error.
+    pub fn finish(mut self) -> Result<Decompressor, Error> {
+        self.verify()?;
+        Ok(self.reader)
+    }
+
+    /// Idempotently validate the accumulated CRC/size against the expected
+    /// values, reading the data descriptor at most once.
+    fn verify(&mut self) -> Result<(), Error> {
+        if !self.verified {
+            self.expected.valid(ZipVerification {
+                crc: self.crc,
+                uncompressed_size: self.size,
+            })?;
+            self.verified = true;
+        }
+        Ok(())
+    }
+}
+
+impl<Decompressor, R> std::io::Read for ZipVerifier<Decompressor, R>
 where
     Decompressor: std::io::Read,
-    Reader: ReaderAt,
+    R: ReaderAt,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // An empty target buffer is not EOF
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         let read = self.reader.read(buf)?;
         self.crc = crc32_chunk(&buf[..read], self.crc);
         self.size += read as u64;
 
-        if read == 0 || self.size >= self.wayfinder.uncompressed_size_hint() {
-            let crc = if self.wayfinder.has_data_descriptor {
-                DataDescriptor::read_at(&self.archive, self.end_offset).map(|x| x.crc)
-            } else {
-                Ok(self.wayfinder.crc)
-            };
+        // Fail oversized streams
+        if self.size > self.expected.uncompressed_size_hint() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                Error::from(ErrorKind::InvalidSize {
+                    expected: self.expected.uncompressed_size_hint(),
+                    actual: self.size,
+                }),
+            ));
+        }
 
-            crc.and_then(|crc| {
-                let expected = ZipVerification {
-                    crc,
-                    uncompressed_size: self.wayfinder.uncompressed_size_hint(),
-                };
-
-                expected.valid(ZipVerification {
-                    crc: self.crc,
-                    uncompressed_size: self.size,
-                })
-            })
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        // Verify once the declared size is reached or at EOF, whichever comes
+        // first, so callers that stop at the known length still get verified.
+        // At size-reached the entry body has been fully streamed, so the data
+        // descriptor read remains deferred until after the body.
+        if read == 0 || self.size >= self.expected.uncompressed_size_hint() {
+            self.verify()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         }
 
         Ok(read)
@@ -881,27 +1149,33 @@ impl<R> ZipReader<R>
 where
     R: ReaderAt,
 {
-    /// Returns an object that can be used to verify the size and checksum of
-    /// inflated data
+    /// Returns a deferred handle that can verify the size and checksum of
+    /// inflated data, recovered from a [`ZipReader`] rather than a [`ZipEntry`].
     ///
-    /// Consumes the reader, so this should be called after all data has been read from the entry.
+    /// This yields the same handle as [`ZipEntry::claim_verifier`] — see there
+    /// for the canonical "bring your own CRC" example and the full set of
+    /// verification styles. Reach for this form when you have consumed the entry
+    /// into a reader stack and no longer hold the originating [`ZipEntry`]: own
+    /// the [`ZipReader`] at the bottom of the stack and call `claim_verifier()`
+    /// transiently at EOF.
     ///
-    /// The function will read the data descriptor if one is expected to exist.
-    pub fn claim_verifier(self) -> Result<ZipVerification, Error> {
-        let expected_size = self.entry.uncompressed_size_hint();
-
-        let expected_crc = if self.entry.has_data_descriptor {
-            let end_offset = self.range_reader.end_offset();
-            let archive = self.range_reader.into_inner();
-            DataDescriptor::read_at(archive, end_offset).map(|x| x.crc)?
-        } else {
-            self.entry.crc
-        };
-
-        Ok(ZipVerification {
-            crc: expected_crc,
-            uncompressed_size: expected_size,
-        })
+    /// When you own the read loop, prefer the capped imperative pattern from
+    /// [`ZipEntry::claim_verifier`]. When a self-verifying [`Read`] must be
+    /// handed to code you don't control, the handle composes into one — see
+    /// the `custom_verifying_reader` integration test for a reference that
+    /// mirrors the policy of
+    /// [`verifying_reader`](ZipEntry::verifying_reader).
+    ///
+    /// The data descriptor (when present) is read lazily, so resolve the handle
+    /// only after all of the entry's data has been read.
+    pub fn claim_verifier(&self) -> ZipReaderVerification<&R> {
+        ZipReaderVerification {
+            archive: self.range_reader.get_ref(),
+            end_offset: self.range_reader.end_offset(),
+            crc: self.entry.crc,
+            uncompressed_size: self.entry.uncompressed_size_hint(),
+            has_data_descriptor: self.entry.has_data_descriptor,
+        }
     }
 }
 

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -1,0 +1,454 @@
+//! "Bring your own CRC" verification.
+//!
+//! rawzip exposes four ways for a caller to supply their own CRC
+//! implementation instead of rawzip's built-in one. They form a 2x2 matrix:
+//! two entry types (slice- vs reader-backed) times two styles (imperative
+//! `claim_verifier().valid(..)` vs the wrapping `verifying_reader(..)`). Each
+//! cell gets a focused test below, all driven from the same [`sample_zip`]
+//! fixture so the setup ceremony doesn't drown out the part that matters.
+
+use rawzip::{ErrorKind, ZipArchive, ZipVerification, RECOMMENDED_BUFFER_SIZE};
+use std::io::{Cursor, Read, Write};
+
+const SAMPLE_DATA: &[u8] = b"Bring your own CRC: hardware intrinsics welcome!";
+
+/// Builds an in-memory Zip with a single deflated entry containing
+/// [`SAMPLE_DATA`]. The writer always emits a data descriptor, so the
+/// authoritative CRC lives *after* the body and the lazy-descriptor path is
+/// exercised.
+fn sample_zip() -> Vec<u8> {
+    let mut output = Vec::new();
+    let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
+    let (mut entry, config) = archive
+        .new_file("file.txt")
+        .compression_method(rawzip::CompressionMethod::Deflate)
+        .start()
+        .unwrap();
+    let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
+    let mut writer = config.wrap(encoder);
+    std::io::copy(&mut &SAMPLE_DATA[..], &mut writer).unwrap();
+    let (_, descriptor) = writer.finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+    output
+}
+
+/// Locates the (single) entry of a reader-backed archive built from `bytes`.
+fn reader_entry(bytes: Vec<u8>, buf: &mut [u8]) -> rawzip::ZipArchive<Vec<u8>> {
+    let end = bytes.len() as u64;
+    rawzip::ZipLocator::new()
+        .locate_in_reader(bytes, buf, end)
+        .map_err(|(_, e)| e)
+        .unwrap()
+}
+
+/// Slice + imperative: own the CRC loop, then call `claim_verifier().valid(..)`.
+#[test]
+fn slice_imperative() {
+    let bytes = sample_zip();
+    let archive = ZipArchive::from_slice(&bytes).unwrap();
+    let mut entries = archive.entries();
+    let header = entries.next_entry().unwrap().unwrap();
+    let entry = archive.get_entry(header.wayfinder()).unwrap();
+
+    // Compute the checksum with a "foreign" CRC (flate2's CrcReader).
+    let decompressor = flate2::read::DeflateDecoder::new(entry.data());
+    let mut reader = flate2::CrcReader::new(decompressor);
+    std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
+
+    let actual = ZipVerification {
+        crc: reader.crc().sum(),
+        uncompressed_size: reader.get_ref().total_out(),
+    };
+
+    let verification = entry.claim_verifier();
+    assert_ne!(actual.crc(), 0, "CRC should not be zero");
+    assert_eq!(verification.expected().unwrap().crc(), actual.crc());
+    verification.valid(actual).unwrap();
+}
+
+/// Slice + wrapping: let rawzip drive the CRC via `verifying_reader`.
+#[test]
+fn slice_wrapping() {
+    let bytes = sample_zip();
+    let archive = ZipArchive::from_slice(&bytes).unwrap();
+    let mut entries = archive.entries();
+    let header = entries.next_entry().unwrap().unwrap();
+    let entry = archive.get_entry(header.wayfinder()).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.data());
+    let mut verifier = entry.verifying_reader(decompressor);
+    let mut actual = Vec::new();
+    std::io::copy(&mut verifier, &mut actual).unwrap();
+    assert_eq!(actual, SAMPLE_DATA);
+}
+
+/// Reader + imperative: own the CRC loop against a reader-backed archive.
+#[test]
+fn reader_imperative() {
+    let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = reader_entry(sample_zip(), &mut buf);
+    let wayfinder = {
+        let mut entries = archive.entries(&mut buf);
+        entries.next_entry().unwrap().unwrap().wayfinder()
+    };
+    let entry = archive.get_entry(wayfinder).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.reader());
+    let mut reader = flate2::CrcReader::new(decompressor);
+    std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
+
+    let actual = ZipVerification {
+        crc: reader.crc().sum(),
+        uncompressed_size: reader.get_ref().total_out(),
+    };
+
+    let verification = entry.claim_verifier();
+    assert_ne!(actual.crc(), 0, "CRC should not be zero");
+    assert_eq!(verification.expected().unwrap().crc(), actual.crc());
+    verification.valid(actual).unwrap();
+}
+
+/// Reader + wrapping: let rawzip drive the CRC via `verifying_reader`.
+#[test]
+fn reader_wrapping() {
+    let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = reader_entry(sample_zip(), &mut buf);
+    let wayfinder = {
+        let mut entries = archive.entries(&mut buf);
+        entries.next_entry().unwrap().unwrap().wayfinder()
+    };
+    let entry = archive.get_entry(wayfinder).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.reader());
+    let mut verifier = entry.verifying_reader(decompressor);
+    let mut actual = Vec::new();
+    std::io::copy(&mut verifier, &mut actual).unwrap();
+    assert_eq!(actual, SAMPLE_DATA);
+}
+
+/// Slice + `finish()`: read exactly the known number of bytes (never hitting
+/// EOF). Verification auto-triggers on the read that reaches the declared
+/// size — lazily parsing the descriptor — and `finish()` then short-circuits,
+/// handing back the inner reader.
+#[test]
+fn slice_finish_success() {
+    let bytes = sample_zip();
+    let archive = ZipArchive::from_slice(&bytes).unwrap();
+    let mut entries = archive.entries();
+    let header = entries.next_entry().unwrap().unwrap();
+    let entry = archive.get_entry(header.wayfinder()).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.data());
+    let mut verifier = entry.verifying_reader(decompressor);
+
+    // Read exactly the known length; read_exact stops once the buffer is full
+    // (never returning Ok(0)), and verification auto-triggers at the size
+    // threshold.
+    let mut out = vec![0u8; SAMPLE_DATA.len()];
+    verifier.read_exact(&mut out).unwrap();
+    assert_eq!(out, SAMPLE_DATA);
+
+    // finish() short-circuits (already verified) and hands back the inner reader.
+    verifier.finish().unwrap();
+}
+
+/// Slice + `finish()` under-read: stopping short of the known length must
+/// surface as an `InvalidSize` error.
+#[test]
+fn slice_finish_under_read() {
+    let bytes = sample_zip();
+    let archive = ZipArchive::from_slice(&bytes).unwrap();
+    let mut entries = archive.entries();
+    let header = entries.next_entry().unwrap().unwrap();
+    let entry = archive.get_entry(header.wayfinder()).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.data());
+    let mut verifier = entry.verifying_reader(decompressor);
+
+    let mut out = vec![0u8; SAMPLE_DATA.len() - 1];
+    verifier.read_exact(&mut out).unwrap();
+
+    let err = verifier.finish().unwrap_err();
+    match err.kind() {
+        ErrorKind::InvalidSize { expected, actual } => {
+            assert_eq!(*expected, SAMPLE_DATA.len() as u64);
+            assert_eq!(*actual, (SAMPLE_DATA.len() - 1) as u64);
+        }
+        other => panic!("expected InvalidSize error, got {:?}", other),
+    }
+}
+
+/// Reader + `finish()`: same as `slice_finish_success` but against a
+/// reader-backed archive, whose descriptor CRC is read lazily (positioned
+/// read) when verification auto-triggers at the size threshold.
+#[test]
+fn reader_finish_success() {
+    let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = reader_entry(sample_zip(), &mut buf);
+    let wayfinder = {
+        let mut entries = archive.entries(&mut buf);
+        entries.next_entry().unwrap().unwrap().wayfinder()
+    };
+    let entry = archive.get_entry(wayfinder).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.reader());
+    let mut verifier = entry.verifying_reader(decompressor);
+
+    let mut out = vec![0u8; SAMPLE_DATA.len()];
+    verifier.read_exact(&mut out).unwrap();
+    assert_eq!(out, SAMPLE_DATA);
+
+    verifier.finish().unwrap();
+}
+
+/// Reader + `finish()` under-read: stopping short must surface as `InvalidSize`.
+#[test]
+fn reader_finish_under_read() {
+    let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = reader_entry(sample_zip(), &mut buf);
+    let wayfinder = {
+        let mut entries = archive.entries(&mut buf);
+        entries.next_entry().unwrap().unwrap().wayfinder()
+    };
+    let entry = archive.get_entry(wayfinder).unwrap();
+
+    let decompressor = flate2::read::DeflateDecoder::new(entry.reader());
+    let mut verifier = entry.verifying_reader(decompressor);
+
+    let mut out = vec![0u8; SAMPLE_DATA.len() - 1];
+    verifier.read_exact(&mut out).unwrap();
+
+    let err = verifier.finish().unwrap_err();
+    match err.kind() {
+        ErrorKind::InvalidSize { expected, actual } => {
+            assert_eq!(*expected, SAMPLE_DATA.len() as u64);
+            assert_eq!(*actual, (SAMPLE_DATA.len() - 1) as u64);
+        }
+        other => panic!("expected InvalidSize error, got {:?}", other),
+    }
+}
+
+/// Reading exactly the known length must auto-verify at the size threshold:
+/// a corrupted CRC surfaces from `read_exact` itself, with no EOF read and no
+/// `finish()` call.
+#[test]
+fn read_exact_auto_verifies_at_known_length() {
+    let mut data = std::fs::read("assets/crc32-not-streamed.zip").unwrap();
+
+    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    assert!(!entry.has_data_descriptor());
+    let size = entry.uncompressed_size_hint() as usize;
+
+    // Mutate the central directory CRC to be incorrect
+    let crc_offset = entry.central_directory_offset() as usize + 16;
+    let original_crc = u32::from_le_bytes(data[crc_offset..crc_offset + 4].try_into().unwrap());
+    let corrupted_crc = original_crc ^ 0xffff_ffff;
+    data[crc_offset..crc_offset + 4].copy_from_slice(&corrupted_crc.to_le_bytes());
+
+    // Slice verifier: the read that reaches the declared size must fail.
+    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let mut verifier = ent.verifying_reader(ent.data());
+    let mut out = vec![0u8; size];
+    let err = verifier.read_exact(&mut out).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let source = err.into_inner().unwrap();
+    let zip_error = source.downcast::<rawzip::Error>().unwrap();
+    assert!(matches!(
+        zip_error.kind(),
+        ErrorKind::InvalidChecksum { .. }
+    ));
+
+    // Reader verifier: same expectation.
+    let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buffer).unwrap();
+    let mut entries = archive.entries(&mut buffer);
+    let entry = entries.next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let mut verifier = ent.verifying_reader(ent.reader());
+    let mut out = vec![0u8; size];
+    let err = verifier.read_exact(&mut out).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let source = err.into_inner().unwrap();
+    let zip_error = source.downcast::<rawzip::Error>().unwrap();
+    assert!(matches!(
+        zip_error.kind(),
+        ErrorKind::InvalidChecksum { .. }
+    ));
+}
+
+/// A user-defined verifying reader composed from the `claim_verifier()`
+/// building block, for when a self-verifying `Read` must be handed to code
+/// you don't control (e.g. a tar parser). When you own the read loop, prefer
+/// `verifying_reader` or the capped imperative pattern from the
+/// `ZipEntry::claim_verifier` docs instead.
+///
+/// This mirrors the policy of `ZipVerifier::read`, the canonical
+/// implementation: empty-buffer guard, fail-fast size bound, and verification
+/// once the declared size is reached or EOF is hit, whichever comes first.
+/// Policy changes there should be reflected here.
+struct CustomZipVerifier<R> {
+    reader: flate2::CrcReader<rawzip::ZipReader<R>>,
+    size: u64,
+    verified: bool,
+}
+
+impl<R> Read for CustomZipVerifier<R>
+where
+    R: rawzip::ReaderAt,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Guard against an empty buffer being misinterpreted as EOF.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let read = self.reader.read(buf)?;
+        self.size += read as u64;
+
+        // Constructing the handle is a cheap field copy (no I/O). It borrows
+        // the `ZipReader` owned by this struct, so it is constructed
+        // transiently rather than stored.
+        let verifier = self.reader.get_ref().claim_verifier();
+
+        // Fail fast on an oversized stream
+        if self.size > verifier.uncompressed_size_hint() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                rawzip::Error::from(rawzip::ErrorKind::InvalidSize {
+                    expected: verifier.uncompressed_size_hint(),
+                    actual: self.size,
+                }),
+            ));
+        }
+
+        // Verify once the declared size is reached or at EOF, whichever
+        // comes first.
+        if (read == 0 || self.size >= verifier.uncompressed_size_hint()) && !self.verified {
+            let actual = ZipVerification {
+                crc: self.reader.crc().sum(),
+                uncompressed_size: self.size,
+            };
+            verifier
+                .valid(actual)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            self.verified = true;
+        }
+
+        Ok(read)
+    }
+}
+
+#[test]
+fn custom_verifying_reader() {
+    // Build a Stored entry (compressed == uncompressed); the writer always emits
+    // a data descriptor, so the authoritative CRC lives *after* the body. The
+    // custom reader CRCs the raw bytes directly, which only matches the stored
+    // value because the entry is uncompressed.
+    let data = b"deferred descriptor verification body bytes";
+    let mut output = Cursor::new(Vec::new());
+    let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
+    let (mut entry, config) = archive.new_file("deferred.bin").start().unwrap();
+    let mut writer = config.wrap(&mut entry);
+    writer.write_all(data).unwrap();
+    let (_, descriptor) = writer.finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+    let bytes = output.into_inner();
+
+    // Use a reader-backed archive so the custom wrapper drives the `ZipReader`
+    // verification path (whose CRC comes from the data descriptor).
+    let mut buf = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = ZipArchive::from_seekable(Cursor::new(bytes), &mut buf).unwrap();
+    let wayfinder = {
+        let mut entries = archive.entries(&mut buf);
+        let header = entries.next_entry().unwrap().unwrap();
+        assert!(header.has_data_descriptor());
+        header.wayfinder()
+    };
+    let entry = archive.get_entry(wayfinder).unwrap();
+
+    let mut verifier = CustomZipVerifier {
+        reader: flate2::CrcReader::new(entry.reader()),
+        size: 0,
+        verified: false,
+    };
+
+    // An empty buffer is not EOF and must not trigger (premature) verification.
+    assert_eq!(verifier.read(&mut []).unwrap(), 0);
+    assert!(!verifier.verified);
+
+    let n = std::io::copy(&mut verifier, &mut std::io::sink()).unwrap();
+    assert_eq!(n, data.len() as u64);
+    assert_eq!(verifier.size, data.len() as u64);
+    assert!(verifier.verified);
+
+    // A redundant read after EOF stays at EOF without re-verifying.
+    assert_eq!(verifier.read(&mut [0u8; 8]).unwrap(), 0);
+}
+
+#[test]
+fn catch_incorrect_crc_without_data_descriptor() {
+    let mut data = std::fs::read("assets/crc32-not-streamed.zip").unwrap();
+
+    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    assert!(!entry.has_data_descriptor());
+
+    // Mutate the central directory CRC to be incorrect
+    let crc_offset = entry.central_directory_offset() as usize + 16;
+    let original_crc = u32::from_le_bytes(data[crc_offset..crc_offset + 4].try_into().unwrap());
+    let corrupted_crc = original_crc ^ 0xffff_ffff;
+    data[crc_offset..crc_offset + 4].copy_from_slice(&corrupted_crc.to_le_bytes());
+
+    // Ensure that the slice verifier rejects the bad CRC
+    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let mut verifier = ent.verifying_reader(ent.data());
+    let slice_result = std::io::copy(&mut verifier, &mut std::io::sink());
+
+    let err = slice_result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let source = err.into_inner().unwrap();
+    let zip_error = source.downcast::<rawzip::Error>().unwrap();
+    match zip_error.kind() {
+        ErrorKind::InvalidChecksum { expected, actual } => {
+            assert_eq!(*expected, corrupted_crc);
+            assert_eq!(*actual, original_crc);
+        }
+        other => panic!("expected InvalidChecksum error, got {:?}", other),
+    }
+
+    // Ensure that the reader verifier rejects the bad CRC
+    let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buffer).unwrap();
+    let mut entries = archive.entries(&mut buffer);
+    let entry = entries.next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let mut verifier = ent.verifying_reader(ent.reader());
+    let reader_result = std::io::copy(&mut verifier, &mut std::io::sink());
+
+    let err = reader_result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let source = err.into_inner().unwrap();
+    let zip_error = source.downcast::<rawzip::Error>().unwrap();
+    match zip_error.kind() {
+        ErrorKind::InvalidChecksum { expected, actual } => {
+            assert_eq!(*expected, corrupted_crc);
+            assert_eq!(*actual, original_crc);
+        }
+        other => panic!("expected InvalidChecksum error, got {:?}", other),
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::Path;
 
+mod crc_tests;
 mod extra_data_zip_tests;
 mod extra_fields_test;
 mod false_signature_tests;
@@ -818,65 +819,6 @@ fn errors_eq(a: &Error, b: &ErrorKind) -> bool {
     }
 }
 
-#[test]
-fn catch_incorrect_crc_without_data_descriptor() {
-    let mut data = std::fs::read("assets/crc32-not-streamed.zip").unwrap();
-
-    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
-    let mut entries = archive.entries();
-    let entry = entries.next_entry().unwrap().unwrap();
-    assert!(!entry.has_data_descriptor());
-
-    // Mutate the central directory CRC to be incorrect
-    let crc_offset = entry.central_directory_offset() as usize + 16;
-    let original_crc = u32::from_le_bytes(data[crc_offset..crc_offset + 4].try_into().unwrap());
-    let corrupted_crc = original_crc ^ 0xffff_ffff;
-    data[crc_offset..crc_offset + 4].copy_from_slice(&corrupted_crc.to_le_bytes());
-
-    // Ensure that the slice verifier rejects the bad CRC
-    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
-    let mut entries = archive.entries();
-    let entry = entries.next_entry().unwrap().unwrap();
-    let ent = archive.get_entry(entry.wayfinder()).unwrap();
-
-    let mut verifier = ent.verifying_reader(ent.data());
-    let slice_result = std::io::copy(&mut verifier, &mut std::io::sink());
-
-    let err = slice_result.unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
-    let source = err.into_inner().unwrap();
-    let zip_error = source.downcast::<rawzip::Error>().unwrap();
-    match zip_error.kind() {
-        ErrorKind::InvalidChecksum { expected, actual } => {
-            assert_eq!(*expected, corrupted_crc);
-            assert_eq!(*actual, original_crc);
-        }
-        other => panic!("expected InvalidChecksum error, got {:?}", other),
-    }
-
-    // Ensure that the reader verifier rejects the bad CRC
-    let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
-    let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buffer).unwrap();
-    let mut entries = archive.entries(&mut buffer);
-    let entry = entries.next_entry().unwrap().unwrap();
-    let ent = archive.get_entry(entry.wayfinder()).unwrap();
-
-    let mut verifier = ent.verifying_reader(ent.reader());
-    let reader_result = std::io::copy(&mut verifier, &mut std::io::sink());
-
-    let err = reader_result.unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
-    let source = err.into_inner().unwrap();
-    let zip_error = source.downcast::<rawzip::Error>().unwrap();
-    match zip_error.kind() {
-        ErrorKind::InvalidChecksum { expected, actual } => {
-            assert_eq!(*expected, corrupted_crc);
-            assert_eq!(*actual, original_crc);
-        }
-        other => panic!("expected InvalidChecksum error, got {:?}", other),
-    }
-}
-
 /// This test is to ensure that the ZipArchive can be created from a Vec<u8>
 #[test]
 fn zip_integration_tests_vec() {
@@ -1174,38 +1116,4 @@ fn test_ff_optimized_jar_reader() {
     let count = std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
     assert_eq!(first.uncompressed_size_hint(), count);
     entries.next_entry().unwrap_err();
-}
-
-#[test]
-fn test_custom_crc_reader() {
-    // Tests that consumers can "bring their own CRC" if they want
-    let f = File::open("assets/test.zip").unwrap();
-    let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
-    let archive = ZipArchive::from_file(f, &mut buf).unwrap();
-    let mut entries = archive.entries(&mut buf);
-    let entry = entries.next_entry().unwrap().unwrap();
-    assert_eq!(
-        entry.compression_method(),
-        rawzip::CompressionMethod::Deflate
-    );
-    let wayfinder = entry.wayfinder();
-    let ent = archive.get_entry(wayfinder).unwrap();
-    let zip_reader = ent.reader();
-    let decoder = flate2::read::DeflateDecoder::new(zip_reader);
-
-    let mut reader = flate2::CrcReader::new(decoder);
-    std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
-
-    let actual_crc = reader.crc().sum();
-    let size = reader.get_ref().total_out();
-    let zip_reader = reader.into_inner().into_inner();
-    let verification = zip_reader.claim_verifier().unwrap();
-    assert_ne!(actual_crc, 0, "CRC should not be zero");
-    assert_eq!(verification.crc(), actual_crc);
-    verification
-        .valid(rawzip::ZipVerification {
-            crc: actual_crc,
-            uncompressed_size: size,
-        })
-        .unwrap();
 }


### PR DESCRIPTION
`ZipSliceArchive::get_entry` eagerly parsed the trailing data descriptor at lookup time, before any of the entry body had been read, risking a cache miss or page fault (ie: mmap-backed slices).

So this reworks `claim_verifier` on both paths into a deferred verification handle that does no parsing or I/O on construction. The data descriptor is resolved lazily.

Breaking changes:

- `ZipReader::claim_verifier` borrows self and returns an infallible handle (same with `ZipSliceEntry`)
- `ZipSliceVerifier` gained a lifetime parameter to support the deferred data descriptor read

New:

- `ZipEntry::claim_verifier` convenience for `ZipReader::claim_verifier`
- `ZipSliceVerification` / `ZipReaderVerification` deferred handles
- `ZipVerifier::finish` / `ZipSliceVerifier::finish` to force verification when stopping at the known length instead of reading to EOF.

Fixes:

- An empty target buffer is no longer treated as EOF (it previously triggered early verification).

The slice `get_entry` still eagerly validates only the compressed body is present; the data descriptor, like the reader path, is validated lazily when the handle is resolved.

Those that to preserve the old behavior can call
`ZipSliceVerification::expected` after `get_entry`.

Closes #123 