### PR TITLE
Consolidate CompressionMethod into a single u16 newtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
 
 // Start of a new file in our zip archive with deflate compression.
 let (mut entry, config) = archive.new_file("file.txt")
-    .compression_method(rawzip::CompressionMethod::Deflate)
+    .compression_method(rawzip::CompressionMethod::DEFLATE)
     .start()?;
 
 // Create the deflate compressor
@@ -70,7 +70,7 @@ let entry = entries.next_entry()?.unwrap();
 assert_eq!(entry.file_path().try_normalize()?.as_ref(), "file.txt");
 
 // Assert the compression method.
-assert_eq!(entry.compression_method(), rawzip::CompressionMethod::Deflate);
+assert_eq!(entry.compression_method(), rawzip::CompressionMethod::DEFLATE);
 
 // Assert the uncompressed size hint. Be warned that this may not be the actual,
 // uncompressed size for malicious or corrupted files.

--- a/bench/src/shared.rs
+++ b/bench/src/shared.rs
@@ -130,7 +130,7 @@ pub fn create_test_zip(entry_count: usize) -> Vec<u8> {
     for file_name in file_names(entry_count) {
         let (mut entry, config) = archive
             .new_file(&file_name)
-            .compression_method(rawzip::CompressionMethod::Store)
+            .compression_method(rawzip::CompressionMethod::STORE)
             .start()
             .unwrap();
         let mut writer = config.wrap(&mut entry);

--- a/bench/src/writer.rs
+++ b/bench/src/writer.rs
@@ -17,7 +17,7 @@ fn write_archive(
         for file_name in file_names {
             let mut builder = archive
                 .new_file(file_name)
-                .compression_method(rawzip::CompressionMethod::Store);
+                .compression_method(rawzip::CompressionMethod::STORE);
 
             if let Some(last_modified) = last_modified {
                 builder = builder.last_modified(last_modified);

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -13,7 +13,7 @@ fn create_test_zip<const TIMESTAMP: bool>(entries: usize) -> Vec<u8> {
     for i in 0..entries {
         let mut file_builder = archive
             .new_file(names.name_of(i))
-            .compression_method(rawzip::CompressionMethod::Store);
+            .compression_method(rawzip::CompressionMethod::STORE);
         if TIMESTAMP {
             file_builder = file_builder.last_modified(jan_1_2001);
         }

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let (mut entry, config) = archive
             .new_file(&filename)
-            .compression_method(rawzip::CompressionMethod::Store)
+            .compression_method(rawzip::CompressionMethod::STORE)
             .start()?;
 
         let mut data_writer = config.wrap(&mut entry);
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (mut big_entry, config) = archive
         .new_file("big_zeros.dat")
-        .compression_method(rawzip::CompressionMethod::Zstd)
+        .compression_method(rawzip::CompressionMethod::ZSTD)
         .start()?;
 
     let encoder = zstd::Encoder::new(&mut big_entry, 3)?; // Compression level 3
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let mut big_file_wayfinder = None;
-    let mut big_file_compression = rawzip::CompressionMethod::Store;
+    let mut big_file_compression = rawzip::CompressionMethod::STORE;
     let mut entries = archive.entries(&mut buffer);
     let mut entry_count = 0;
     while let Some(entry) = entries.next_entry()? {
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(
         big_file_compression,
-        rawzip::CompressionMethod::Zstd,
+        rawzip::CompressionMethod::ZSTD,
         "Expected big_zeros.dat to use Zstd compression"
     );
     let decoder = zstd::Decoder::new(reader)?;

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -172,7 +172,7 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
         let uncompressed_size = entry.uncompressed_size_hint();
         if compressed_size > 0
             && uncompressed_size / compressed_size > 1032
-            && matches!(entry.compression_method(), CompressionMethod::Deflate)
+            && matches!(entry.compression_method(), CompressionMethod::DEFLATE)
         {
             eprintln!(
                 "Skipped potential zip bomb: compression ratio {:.1}:1 exceeds limit of 1032:1 for file: {file_path:?}",
@@ -189,7 +189,7 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
         })?;
         let method = entry.compression_method();
         match method {
-            CompressionMethod::Store => {
+            CompressionMethod::STORE => {
                 let mut verifier = zip_entry.verifying_reader(reader);
                 std::io::copy(&mut verifier, &mut outfile).map_err(|e| {
                     ExtractionError::io_context(
@@ -201,7 +201,7 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
                     )
                 })?;
             }
-            CompressionMethod::Deflate => {
+            CompressionMethod::DEFLATE => {
                 let inflater = flate2::read::DeflateDecoder::new(reader);
                 let mut verifier = zip_entry.verifying_reader(inflater);
                 std::io::copy(&mut verifier, &mut outfile).map_err(|e| {
@@ -211,7 +211,7 @@ fn extract_zip_archive<P: AsRef<std::path::Path>>(
                     )
                 })?;
             }
-            CompressionMethod::Zstd | CompressionMethod::ZstdDeprecated => {
+            CompressionMethod::ZSTD | CompressionMethod::ZSTD_DEPRECATED => {
                 let decoder = zstd::Decoder::new(reader).map_err(|e| {
                     ExtractionError::io_context(
                         e,

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -51,16 +51,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stdout_lock = stdout.lock();
 
     match compression_method {
-        rawzip::CompressionMethod::Store => {
+        rawzip::CompressionMethod::STORE => {
             let mut verifier = zip_entry.verifying_reader(reader);
             io::copy(&mut verifier, &mut stdout_lock)?;
         }
-        rawzip::CompressionMethod::Deflate => {
+        rawzip::CompressionMethod::DEFLATE => {
             let inflater = flate2::read::DeflateDecoder::new(reader);
             let mut verifier = zip_entry.verifying_reader(inflater);
             io::copy(&mut verifier, &mut stdout_lock)?;
         }
-        rawzip::CompressionMethod::Zstd => {
+        rawzip::CompressionMethod::ZSTD => {
             let decoder = zstd::Decoder::new(reader)?;
             let mut verifier = zip_entry.verifying_reader(decoder);
             io::copy(&mut verifier, &mut stdout_lock)?;

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -30,9 +30,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let compression_method = if use_zstd {
-        rawzip::CompressionMethod::Zstd
+        rawzip::CompressionMethod::ZSTD
     } else {
-        rawzip::CompressionMethod::Deflate
+        rawzip::CompressionMethod::DEFLATE
     };
 
     let output_path = positional_args[0];
@@ -95,7 +95,7 @@ fn add_file_to_archive<W: Write>(
     let mut file = fs::File::open(file_path)?;
     let (mut entry, config) = builder.start()?;
     match compression_method {
-        rawzip::CompressionMethod::Deflate => {
+        rawzip::CompressionMethod::DEFLATE => {
             let encoder =
                 flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
             let mut writer = config.wrap(encoder);
@@ -104,7 +104,7 @@ fn add_file_to_archive<W: Write>(
             encoder.finish()?;
             entry.finish(output)?;
         }
-        rawzip::CompressionMethod::Zstd => {
+        rawzip::CompressionMethod::ZSTD => {
             let encoder = zstd::Encoder::new(&mut entry, 3)?;
             let mut writer = config.wrap(encoder);
             std::io::copy(&mut file, &mut writer)?;

--- a/fuzz/fuzz_targets/fuzz_zip.rs
+++ b/fuzz/fuzz_targets/fuzz_zip.rs
@@ -62,14 +62,14 @@ fn fuzz_reader_zip_archive(data: &[u8], buf: &mut [u8]) -> Result<(), rawzip::Er
         };
         let _range = ent.compressed_data_range();
         match entry.compression_method() {
-            rawzip::CompressionMethod::Store => {
+            rawzip::CompressionMethod::STORE => {
                 let mut verifier = ent.verifying_reader(ent.reader());
                 let mut sink = std::io::sink();
                 let Ok(_) = std::io::copy(&mut verifier, &mut sink) else {
                     continue;
                 };
             }
-            rawzip::CompressionMethod::Deflate => {
+            rawzip::CompressionMethod::DEFLATE => {
                 let inflater = flate2::read::DeflateDecoder::new(ent.reader());
                 let mut verifier = ent.verifying_reader(inflater);
                 let mut sink = std::io::sink();
@@ -107,14 +107,14 @@ fn fuzz_slice_zip_archive(data: &[u8]) -> Result<(), rawzip::Error> {
         let _extra_fields = _local_header.extra_fields();
         let _range = ent.compressed_data_range();
         match entry.compression_method() {
-            rawzip::CompressionMethod::Store => {
+            rawzip::CompressionMethod::STORE => {
                 let mut verifier = ent.verifying_reader(ent.data());
                 let mut sink = std::io::sink();
                 let Ok(_) = std::io::copy(&mut verifier, &mut sink) else {
                     continue;
                 };
             }
-            rawzip::CompressionMethod::Deflate => {
+            rawzip::CompressionMethod::DEFLATE => {
                 let inflater = flate2::read::DeflateDecoder::new(ent.data());
                 let mut verifier = ent.verifying_reader(inflater);
                 let mut sink = std::io::sink();

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -528,7 +528,7 @@ impl<'a> ZipLocalFileHeader<'a> {
     /// Returns the compression method declared in the local file header.
     #[inline]
     pub fn compression_method(&self) -> CompressionMethod {
-        self.fixed.compression_method.as_method()
+        self.fixed.compression_method
     }
 
     /// Returns the last modification date and time declared in the local file header.
@@ -831,122 +831,167 @@ impl Zip64EndOfCentralDirectoryRecord {
     }
 }
 
-/// A numeric identifier for a compression method used in a Zip archive.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CompressionMethodId(u16);
+/// The compression method used on an individual Zip archive entry.
+///
+/// Contains associated consts for compression methods mentioned in the spec (§
+/// 4.4.5).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CompressionMethod(u16);
 
-impl CompressionMethodId {
-    /// Returns the raw `u16` value of the compression method ID.
+impl CompressionMethod {
+    /// No compression.
+    pub const STORE: Self = Self(0);
+    pub const SHRUNK: Self = Self(1);
+    pub const REDUCE1: Self = Self(2);
+    pub const REDUCE2: Self = Self(3);
+    pub const REDUCE3: Self = Self(4);
+    pub const REDUCE4: Self = Self(5);
+    pub const IMPLODED: Self = Self(6);
+    pub const TOKENIZING: Self = Self(7);
+    /// Deflate.
+    pub const DEFLATE: Self = Self(8);
+    pub const DEFLATE64: Self = Self(9);
+    /// PKWARE DCL Imploding. Historically also labeled "old IBM TERSE" in some
+    /// APPNOTE revisions; method 18 ([`CompressionMethod::TERSE`]) is the
+    /// current ("new") IBM TERSE.
+    pub const DCL_IMPLODE: Self = Self(10);
+    pub const BZIP2: Self = Self(12);
+    pub const LZMA: Self = Self(14);
+    /// IBM CMPSC compression.
+    pub const CMPSC: Self = Self(16);
+    /// IBM TERSE (new).
+    pub const TERSE: Self = Self(18);
+    /// IBM LZ77 z Architecture (PFS).
+    pub const LZ77: Self = Self(19);
+    /// Deprecated zstd id; use [`CompressionMethod::ZSTD`] (93) for zstd.
+    pub const ZSTD_DEPRECATED: Self = Self(20);
+    /// Zstandard.
+    pub const ZSTD: Self = Self(93);
+    pub const MP3: Self = Self(94);
+    pub const XZ: Self = Self(95);
+    pub const JPEG: Self = Self(96);
+    pub const WAVPACK: Self = Self(97);
+    pub const PPMD: Self = Self(98);
+    /// AES encryption.
+    pub const AES: Self = Self(99);
+
+    /// Wrap a raw compression-method id.
     #[inline]
-    pub fn as_u16(&self) -> u16 {
+    pub const fn new(id: u16) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw value of the compression method.
+    #[inline]
+    pub const fn as_u16(self) -> u16 {
         self.0
     }
 
-    /// Converts the numeric ID to a `CompressionMethod` enum.
+    /// Returns the method name (eg" `"DEFLATE"`) when known
     #[inline]
-    pub fn as_method(&self) -> CompressionMethod {
+    pub const fn name(self) -> Option<&'static str> {
         match self.0 {
-            0 => CompressionMethod::Store,
-            1 => CompressionMethod::Shrunk,
-            2 => CompressionMethod::Reduce1,
-            3 => CompressionMethod::Reduce2,
-            4 => CompressionMethod::Reduce3,
-            5 => CompressionMethod::Reduce4,
-            6 => CompressionMethod::Imploded,
-            7 => CompressionMethod::Tokenizing,
-            8 => CompressionMethod::Deflate,
-            9 => CompressionMethod::Deflate64,
-            10 => CompressionMethod::DclImplode,
-            12 => CompressionMethod::Bzip2,
-            14 => CompressionMethod::Lzma,
-            16 => CompressionMethod::Cmpsc,
-            18 => CompressionMethod::Terse,
-            19 => CompressionMethod::Lz77,
-            20 => CompressionMethod::ZstdDeprecated,
-            93 => CompressionMethod::Zstd,
-            94 => CompressionMethod::Mp3,
-            95 => CompressionMethod::Xz,
-            96 => CompressionMethod::Jpeg,
-            97 => CompressionMethod::WavPack,
-            98 => CompressionMethod::Ppmd,
-            99 => CompressionMethod::Aes,
-            _ => CompressionMethod::Unknown(self.0),
+            0 => Some("STORE"),
+            1 => Some("SHRUNK"),
+            2 => Some("REDUCE1"),
+            3 => Some("REDUCE2"),
+            4 => Some("REDUCE3"),
+            5 => Some("REDUCE4"),
+            6 => Some("IMPLODED"),
+            7 => Some("TOKENIZING"),
+            8 => Some("DEFLATE"),
+            9 => Some("DEFLATE64"),
+            10 => Some("DCL_IMPLODE"),
+            12 => Some("BZIP2"),
+            14 => Some("LZMA"),
+            16 => Some("CMPSC"),
+            18 => Some("TERSE"),
+            19 => Some("LZ77"),
+            20 => Some("ZSTD_DEPRECATED"),
+            93 => Some("ZSTD"),
+            94 => Some("MP3"),
+            95 => Some("XZ"),
+            96 => Some("JPEG"),
+            97 => Some("WAVPACK"),
+            98 => Some("PPMD"),
+            99 => Some("AES"),
+            _ => None,
         }
     }
 }
 
-/// The compression method used on an individual Zip archive entry
-///
-/// Documented in the spec under: 4.4.5
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u16)]
-pub enum CompressionMethod {
-    Store = 0,
-    Shrunk = 1,
-    Reduce1 = 2,
-    Reduce2 = 3,
-    Reduce3 = 4,
-    Reduce4 = 5,
-    Imploded = 6,
-    Tokenizing = 7,
-    Deflate = 8,
-    Deflate64 = 9,
-    DclImplode = 10,
-    Bzip2 = 12,
-    Lzma = 14,
-    Cmpsc = 16,
-    Terse = 18,
-    Lz77 = 19,
-    ZstdDeprecated = 20,
-    Zstd = 93,
-    Mp3 = 94,
-    Xz = 95,
-    Jpeg = 96,
-    WavPack = 97,
-    Ppmd = 98,
-    Aes = 99,
-    Unknown(u16),
+impl core::fmt::Debug for CompressionMethod {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.name() {
+            Some(name) => write!(f, "CompressionMethod::{name}"),
+            None => write!(f, "CompressionMethod({})", self.0),
+        }
+    }
 }
 
-impl CompressionMethod {
-    /// Return the numeric id of this compression method.
-    #[inline]
-    pub fn as_id(&self) -> CompressionMethodId {
-        let value = match self {
-            CompressionMethod::Store => 0,
-            CompressionMethod::Shrunk => 1,
-            CompressionMethod::Reduce1 => 2,
-            CompressionMethod::Reduce2 => 3,
-            CompressionMethod::Reduce3 => 4,
-            CompressionMethod::Reduce4 => 5,
-            CompressionMethod::Imploded => 6,
-            CompressionMethod::Tokenizing => 7,
-            CompressionMethod::Deflate => 8,
-            CompressionMethod::Deflate64 => 9,
-            CompressionMethod::DclImplode => 10,
-            CompressionMethod::Bzip2 => 12,
-            CompressionMethod::Lzma => 14,
-            CompressionMethod::Cmpsc => 16,
-            CompressionMethod::Terse => 18,
-            CompressionMethod::Lz77 => 19,
-            CompressionMethod::ZstdDeprecated => 20,
-            CompressionMethod::Zstd => 93,
-            CompressionMethod::Mp3 => 94,
-            CompressionMethod::Xz => 95,
-            CompressionMethod::Jpeg => 96,
-            CompressionMethod::WavPack => 97,
-            CompressionMethod::Ppmd => 98,
-            CompressionMethod::Aes => 99,
-            CompressionMethod::Unknown(id) => *id,
-        };
-        CompressionMethodId(value)
+impl core::fmt::Display for CompressionMethod {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} ({})", self.0, self.name().unwrap_or("UNKNOWN"))
     }
 }
 
 impl From<u16> for CompressionMethod {
     fn from(id: u16) -> Self {
-        CompressionMethodId(id).as_method()
+        Self(id)
     }
+}
+
+// Backwards-compat aliases for the old enum variant names.
+#[allow(non_upper_case_globals)]
+impl CompressionMethod {
+    #[deprecated(note = "use CompressionMethod::STORE")]
+    pub const Store: Self = Self::STORE;
+    #[deprecated(note = "use CompressionMethod::SHRUNK")]
+    pub const Shrunk: Self = Self::SHRUNK;
+    #[deprecated(note = "use CompressionMethod::REDUCE1")]
+    pub const Reduce1: Self = Self::REDUCE1;
+    #[deprecated(note = "use CompressionMethod::REDUCE2")]
+    pub const Reduce2: Self = Self::REDUCE2;
+    #[deprecated(note = "use CompressionMethod::REDUCE3")]
+    pub const Reduce3: Self = Self::REDUCE3;
+    #[deprecated(note = "use CompressionMethod::REDUCE4")]
+    pub const Reduce4: Self = Self::REDUCE4;
+    #[deprecated(note = "use CompressionMethod::IMPLODED")]
+    pub const Imploded: Self = Self::IMPLODED;
+    #[deprecated(note = "use CompressionMethod::TOKENIZING")]
+    pub const Tokenizing: Self = Self::TOKENIZING;
+    #[deprecated(note = "use CompressionMethod::DEFLATE")]
+    pub const Deflate: Self = Self::DEFLATE;
+    #[deprecated(note = "use CompressionMethod::DEFLATE64")]
+    pub const Deflate64: Self = Self::DEFLATE64;
+    #[deprecated(note = "use CompressionMethod::DCL_IMPLODE")]
+    pub const DclImplode: Self = Self::DCL_IMPLODE;
+    #[deprecated(note = "use CompressionMethod::BZIP2")]
+    pub const Bzip2: Self = Self::BZIP2;
+    #[deprecated(note = "use CompressionMethod::LZMA")]
+    pub const Lzma: Self = Self::LZMA;
+    #[deprecated(note = "use CompressionMethod::CMPSC")]
+    pub const Cmpsc: Self = Self::CMPSC;
+    #[deprecated(note = "use CompressionMethod::TERSE")]
+    pub const Terse: Self = Self::TERSE;
+    #[deprecated(note = "use CompressionMethod::LZ77")]
+    pub const Lz77: Self = Self::LZ77;
+    #[deprecated(note = "use CompressionMethod::ZSTD_DEPRECATED")]
+    pub const ZstdDeprecated: Self = Self::ZSTD_DEPRECATED;
+    #[deprecated(note = "use CompressionMethod::ZSTD")]
+    pub const Zstd: Self = Self::ZSTD;
+    #[deprecated(note = "use CompressionMethod::MP3")]
+    pub const Mp3: Self = Self::MP3;
+    #[deprecated(note = "use CompressionMethod::XZ")]
+    pub const Xz: Self = Self::XZ;
+    #[deprecated(note = "use CompressionMethod::JPEG")]
+    pub const Jpeg: Self = Self::JPEG;
+    #[deprecated(note = "use CompressionMethod::WAVPACK")]
+    pub const WavPack: Self = Self::WAVPACK;
+    #[deprecated(note = "use CompressionMethod::PPMD")]
+    pub const Ppmd: Self = Self::PPMD;
+    #[deprecated(note = "use CompressionMethod::AES")]
+    pub const Aes: Self = Self::AES;
 }
 
 /// A borrowed data from a Zip archive, typically for comments or non-path text.
@@ -1014,7 +1059,7 @@ pub struct ZipFileHeaderRecord<'a> {
     version_made_by: u16,
     version_needed: u16,
     flags: EntryFlags,
-    compression_method: CompressionMethodId,
+    compression_method: CompressionMethod,
     last_mod_time: u16,
     last_mod_date: u16,
     crc32: u32,
@@ -1197,7 +1242,7 @@ impl<'a> ZipFileHeaderRecord<'a> {
     /// The compression method used to compress the data
     #[inline]
     pub fn compression_method(&self) -> CompressionMethod {
-        self.compression_method.as_method()
+        self.compression_method
     }
 
     /// Returns the file path in its raw form.
@@ -1396,7 +1441,7 @@ pub(crate) struct ZipLocalFileHeaderFixed {
     pub(crate) signature: u32,
     pub(crate) version_needed: u16,
     pub(crate) flags: EntryFlags,
-    pub(crate) compression_method: CompressionMethodId,
+    pub(crate) compression_method: CompressionMethod,
     pub(crate) last_mod_time: u16,
     pub(crate) last_mod_date: u16,
     pub(crate) crc32: u32,
@@ -1419,7 +1464,7 @@ impl ZipLocalFileHeaderFixed {
             signature: le_u32(&data[0..4]),
             version_needed: le_u16(&data[4..6]),
             flags: EntryFlags::new(le_u16(&data[6..8])),
-            compression_method: CompressionMethodId(le_u16(&data[8..10])),
+            compression_method: CompressionMethod::new(le_u16(&data[8..10])),
             last_mod_time: le_u16(&data[10..12]),
             last_mod_date: le_u16(&data[12..14]),
             crc32: le_u32(&data[14..18]),
@@ -1472,7 +1517,7 @@ pub(crate) struct ZipFileHeaderFixed {
     pub version_made_by: u16,
     pub version_needed: u16,
     pub flags: EntryFlags,
-    pub compression_method: CompressionMethodId,
+    pub compression_method: CompressionMethod,
     pub last_mod_time: u16,
     pub last_mod_date: u16,
     pub crc32: u32,
@@ -1515,7 +1560,7 @@ impl ZipFileHeaderFixed {
             version_made_by: le_u16(&data[4..6]),
             version_needed: le_u16(&data[6..8]),
             flags: EntryFlags::new(le_u16(&data[8..10])),
-            compression_method: CompressionMethodId(le_u16(&data[10..12])),
+            compression_method: CompressionMethod::new(le_u16(&data[10..12])),
             last_mod_time: le_u16(&data[12..14]),
             last_mod_date: le_u16(&data[14..16]),
             crc32: le_u32(&data[16..20]),
@@ -1592,6 +1637,13 @@ impl ZipFileHeaderFixed {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compression_method_display() {
+        assert_eq!(CompressionMethod::DEFLATE.to_string(), "8 (DEFLATE)");
+        assert_eq!(CompressionMethod::STORE.to_string(), "0 (STORE)");
+        assert_eq!(CompressionMethod::new(13).to_string(), "13 (UNKNOWN)");
+    }
 
     #[test]
     pub fn trunc_comment_zips() {
@@ -1673,7 +1725,7 @@ mod tests {
             version_made_by: 0,
             version_needed: 0,
             flags: EntryFlags::new(0x08),
-            compression_method: CompressionMethodId(0),
+            compression_method: CompressionMethod::STORE,
             last_mod_time: 0,
             last_mod_date: 0,
             crc32: 0,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -598,7 +598,7 @@ where
     /// Creates the directory entry.
     pub fn create(self) -> Result<(), Error> {
         let options = ZipEntryOptions {
-            compression_method: CompressionMethod::Store, // Directories always use Store
+            compression_method: CompressionMethod::STORE, // Directories always use Store
             modification_time: self.modification_time,
             unix_permissions: self.unix_permissions,
             extra_fields: self.extra_fields,
@@ -643,7 +643,7 @@ where
             signature: ZipLocalFileHeaderFixed::SIGNATURE,
             version_needed: 20,
             flags: EntryFlags::new(flags),
-            compression_method: compression_method.as_id(),
+            compression_method,
             last_mod_time: dos.packed_time(),
             last_mod_date: dos.packed_date(),
             crc32: 0, // must be zero if data descriptor is used (4.4.4)
@@ -729,14 +729,14 @@ where
 
         let file_comment_len = comment_len(&options.file_comment)?;
 
-        self.write_local_header(path_bytes, flags, CompressionMethod::Store, &mut options)?;
+        self.write_local_header(path_bytes, flags, CompressionMethod::STORE, &mut options)?;
 
         self.file_comments.extend_from_slice(&options.file_comment);
 
         let file_header = FileHeader {
             name_len,
             file_comment_len,
-            compression_method: CompressionMethod::Store,
+            compression_method: CompressionMethod::STORE,
             local_header_offset,
             compressed_size: 0,
             uncompressed_size: 0,
@@ -762,7 +762,7 @@ where
     /// # let mut output = Cursor::new(Vec::new());
     /// # let mut archive = rawzip::ZipArchiveWriter::new(&mut output);
     /// let (mut entry, config) = archive.new_file("my-file")
-    ///     .compression_method(rawzip::CompressionMethod::Deflate)
+    ///     .compression_method(rawzip::CompressionMethod::DEFLATE)
     ///     .unix_permissions(0o644)
     ///     .start()?;
     /// let mut writer = config.wrap(&mut entry);
@@ -779,7 +779,7 @@ where
         ZipFileBuilder {
             archive: self,
             path: path.into(),
-            compression_method: CompressionMethod::Store,
+            compression_method: CompressionMethod::STORE,
             modification_time: None,
             unix_permissions: None,
             extra_fields: ExtraFieldsContainer::new(),
@@ -890,7 +890,7 @@ where
                 version_made_by,
                 version_needed,
                 flags: EntryFlags::new(file.flags),
-                compression_method: file.compression_method.as_id(),
+                compression_method: file.compression_method,
                 last_mod_time: dos.packed_time(),
                 last_mod_date: dos.packed_date(),
                 crc32: file.crc,

--- a/src/zipcrypto.rs
+++ b/src/zipcrypto.rs
@@ -188,7 +188,7 @@ const CHUNK: usize = 8 * 1024;
 ///
 /// let (mut entry, config) = archive
 ///     .new_file("test.txt")
-///     .compression_method(CompressionMethod::Deflate)
+///     .compression_method(CompressionMethod::DEFLATE)
 ///     .encrypted(true)
 ///     .start()?;
 ///

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -15,7 +15,7 @@ fn build_deflate_zip(content: &[u8]) -> Vec<u8> {
     let mut archive = ZipArchiveWriter::new(&mut output);
     let (mut entry, config) = archive
         .new_file("file.txt")
-        .compression_method(CompressionMethod::Deflate)
+        .compression_method(CompressionMethod::DEFLATE)
         .start()
         .unwrap();
     let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());

--- a/tests/it/encryption_tests.rs
+++ b/tests/it/encryption_tests.rs
@@ -170,7 +170,7 @@ fn decrypt_winzip_aes_payload<R: Read>(
 
     let mut output = Vec::new();
     let mut decoder = match compression_method {
-        CompressionMethod::Deflate => flate2::read::DeflateDecoder::new(aes_reader),
+        CompressionMethod::DEFLATE => flate2::read::DeflateDecoder::new(aes_reader),
         method => panic!("unsupported AES compression method: {method:?}"),
     };
     decoder.read_to_end(&mut output).unwrap();
@@ -220,13 +220,13 @@ fn decrypt_winzip_aes_entry(path: &str, expected_strength: u8, expected_vendor_v
         vendor_version: expected_vendor_version,
         vendor_id: *b"AE",
         strength: expected_strength,
-        compression_method: CompressionMethod::Deflate,
+        compression_method: CompressionMethod::DEFLATE,
     };
     let mut entries = archive.entries(&mut buffer);
     let entry = entries.next_entry().unwrap().unwrap();
 
     assert_eq!(entry.file_path().as_ref(), b"test.txt");
-    assert_eq!(entry.compression_method(), CompressionMethod::Aes);
+    assert_eq!(entry.compression_method(), CompressionMethod::AES);
     assert!(entry.flags().is_encrypted());
     assert!(!entry.flags().has_strong_encryption());
 
@@ -320,8 +320,8 @@ fn aes_extra_field(vendor_version: u16, strength: u8, method: CompressionMethod)
     // The actual compression method id (8 for deflate) lives here; the entry's
     // own compression method is 99 (AES).
     let method_id = match method {
-        CompressionMethod::Deflate => 8u16,
-        CompressionMethod::Store => 0u16,
+        CompressionMethod::DEFLATE => 8u16,
+        CompressionMethod::STORE => 0u16,
         other => panic!("unsupported AES compression method: {other:?}"),
     };
     field[5..7].copy_from_slice(&method_id.to_le_bytes());
@@ -354,10 +354,10 @@ fn create_winzip_aes_entry(strength: u8, vendor_version: u16, plaintext: &[u8]) 
     let mut output = std::io::Cursor::new(Vec::new());
     let mut archive = ZipArchiveWriter::new(&mut output);
 
-    let extra = aes_extra_field(vendor_version, strength, CompressionMethod::Deflate);
+    let extra = aes_extra_field(vendor_version, strength, CompressionMethod::DEFLATE);
     let (mut entry, config) = archive
         .new_file("test.txt")
-        .compression_method(CompressionMethod::Aes)
+        .compression_method(CompressionMethod::AES)
         .encrypted(true)
         .extra_field(ExtraFieldId::AES, &extra, Header::default())
         .unwrap()
@@ -410,13 +410,13 @@ fn roundtrip_winzip_aes_entry(strength: u8, vendor_version: u16) {
         vendor_version,
         vendor_id: *b"AE",
         strength,
-        compression_method: CompressionMethod::Deflate,
+        compression_method: CompressionMethod::DEFLATE,
     };
 
     let mut entries = archive.entries(&mut buffer);
     let entry = entries.next_entry().unwrap().unwrap();
     assert_eq!(entry.file_path().as_ref(), b"test.txt");
-    assert_eq!(entry.compression_method(), CompressionMethod::Aes);
+    assert_eq!(entry.compression_method(), CompressionMethod::AES);
     assert!(entry.flags().is_encrypted());
     assert!(!entry.flags().has_strong_encryption());
 
@@ -450,7 +450,7 @@ fn roundtrip_winzip_aes_entry(strength: u8, vendor_version: u16) {
         encrypted_entry.reader(),
         compressed_size,
         strength,
-        CompressionMethod::Deflate,
+        CompressionMethod::DEFLATE,
     );
     assert_eq!(decoded, plaintext);
 }
@@ -503,7 +503,7 @@ fn decrypt_zipcrypto_entry() {
     assert_eq!(entry.file_path().as_ref(), b"test.txt");
     // ZipCrypto leaves the compression method untouched; encryption is signaled
     // by general purpose bit 0, not by a dedicated method like WinZip AES.
-    assert_eq!(entry.compression_method(), CompressionMethod::Deflate);
+    assert_eq!(entry.compression_method(), CompressionMethod::DEFLATE);
     assert!(entry.flags().has_data_descriptor());
     assert!(entry.flags().is_encrypted());
 
@@ -603,7 +603,7 @@ fn create_zipcrypto_entry(method: CompressionMethod, plaintext: &[u8]) -> Vec<u8
     // ZipCrypto -> archive. The encryption header is part of the compressed size,
     // which the entry tracks automatically as the encryptor writes through it.
     let descriptor = match method {
-        CompressionMethod::Deflate => {
+        CompressionMethod::DEFLATE => {
             let deflater =
                 flate2::write::DeflateEncoder::new(encryptor, flate2::Compression::default());
             let mut writer = config.wrap(deflater);
@@ -612,7 +612,7 @@ fn create_zipcrypto_entry(method: CompressionMethod, plaintext: &[u8]) -> Vec<u8
             deflater.finish().unwrap(); // drops the encryptor, releasing &mut entry
             descriptor
         }
-        CompressionMethod::Store => {
+        CompressionMethod::STORE => {
             let mut writer = config.wrap(encryptor);
             writer.write_all(plaintext).unwrap();
             let (_encryptor, descriptor) = writer.finish().unwrap();
@@ -659,14 +659,14 @@ fn roundtrip_zipcrypto(method: CompressionMethod, plaintext: &[u8]) {
 
     let mut output = Vec::new();
     match method {
-        CompressionMethod::Deflate => {
+        CompressionMethod::DEFLATE => {
             let inflater = flate2::read::DeflateDecoder::new(decryptor);
             zip_entry
                 .verifying_reader(inflater)
                 .read_to_end(&mut output)
                 .unwrap();
         }
-        CompressionMethod::Store => {
+        CompressionMethod::STORE => {
             zip_entry
                 .verifying_reader(decryptor)
                 .read_to_end(&mut output)
@@ -682,24 +682,24 @@ fn roundtrip_zipcrypto(method: CompressionMethod, plaintext: &[u8]) {
 #[test]
 fn roundtrip_zipcrypto_deflate() {
     let plaintext = b"the quick brown fox jumps over the lazy dog".repeat(8);
-    roundtrip_zipcrypto(CompressionMethod::Deflate, &plaintext);
+    roundtrip_zipcrypto(CompressionMethod::DEFLATE, &plaintext);
 }
 
 #[test]
 fn roundtrip_zipcrypto_store() {
-    roundtrip_zipcrypto(CompressionMethod::Store, b"aaaaaaaaaaaaaaaa\n");
+    roundtrip_zipcrypto(CompressionMethod::STORE, b"aaaaaaaaaaaaaaaa\n");
 }
 
 #[test]
 fn roundtrip_zipcrypto_empty() {
-    roundtrip_zipcrypto(CompressionMethod::Deflate, b"");
+    roundtrip_zipcrypto(CompressionMethod::DEFLATE, b"");
 }
 
 /// Decoding rawzip's own ZipCrypto output with the wrong password must fail.
 #[test]
 fn roundtrip_zipcrypto_wrong_password_fails() {
     let plaintext = b"the quick brown fox".repeat(8);
-    let zip = create_zipcrypto_entry(CompressionMethod::Deflate, &plaintext);
+    let zip = create_zipcrypto_entry(CompressionMethod::DEFLATE, &plaintext);
 
     let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
     let archive = ZipLocator::new()
@@ -734,7 +734,7 @@ fn decrypt_zipcrypto_no_data_descriptor_entry() {
     let entry = entries.next_entry().unwrap().unwrap();
 
     assert_eq!(entry.file_path().as_ref(), b"test.txt");
-    assert_eq!(entry.compression_method(), CompressionMethod::Store);
+    assert_eq!(entry.compression_method(), CompressionMethod::STORE);
     assert!(entry.flags().is_encrypted());
     // The distinguishing trait: no data descriptor, so the check byte is the
     // high byte of the CRC32, not of the DOS mod time.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -548,12 +548,12 @@ fn process_archive_files<R: rawzip::ReaderAt>(
 
                         let mut data = Vec::new();
                         match entry.compression_method() {
-                            rawzip::CompressionMethod::Deflate => {
+                            rawzip::CompressionMethod::DEFLATE => {
                                 let inflater = flate2::read::DeflateDecoder::new(ent.reader());
                                 let mut verifier = ent.verifying_reader(inflater);
                                 std::io::copy(&mut verifier, &mut Cursor::new(&mut data)).unwrap();
                             }
-                            rawzip::CompressionMethod::Store => {
+                            rawzip::CompressionMethod::STORE => {
                                 let mut verifier = ent.verifying_reader(ent.reader());
                                 std::io::copy(&mut verifier, &mut Cursor::new(&mut data)).unwrap();
                             }
@@ -656,12 +656,12 @@ fn process_slice_archive_files(
 
                         let mut data = Vec::new();
                         match entry.compression_method() {
-                            rawzip::CompressionMethod::Deflate => {
+                            rawzip::CompressionMethod::DEFLATE => {
                                 let inflater = flate2::read::DeflateDecoder::new(ent.data());
                                 let mut verifier = ent.verifying_reader(inflater);
                                 std::io::copy(&mut verifier, &mut Cursor::new(&mut data)).unwrap();
                             }
-                            rawzip::CompressionMethod::Store => {
+                            rawzip::CompressionMethod::STORE => {
                                 let mut verifier = ent.verifying_reader(ent.data());
                                 std::io::copy(&mut verifier, &mut Cursor::new(&mut data)).unwrap();
                             }
@@ -967,7 +967,7 @@ fn test_read_what_we_write_slice(data: Vec<u8>) {
         entry.file_path().try_normalize().unwrap().as_ref(),
         "file.txt"
     );
-    assert_eq!(entry.compression_method(), rawzip::CompressionMethod::Store);
+    assert_eq!(entry.compression_method(), rawzip::CompressionMethod::STORE);
     assert_eq!(entry.uncompressed_size_hint(), data.len() as u64);
     assert_eq!(entry.compressed_size_hint(), data.len() as u64);
     let wayfinder = entry.wayfinder();
@@ -1200,7 +1200,7 @@ fn test_ff_optimized_jar() {
     let entry = archive.get_entry(wayfinder).unwrap();
     assert_eq!(
         first.compression_method(),
-        rawzip::CompressionMethod::Deflate
+        rawzip::CompressionMethod::DEFLATE
     );
     let reader = flate2::read::DeflateDecoder::new(entry.data());
     let mut reader = entry.verifying_reader(reader);
@@ -1225,7 +1225,7 @@ fn test_ff_optimized_jar_reader() {
     let entry = archive.get_entry(wayfinder).unwrap();
     assert_eq!(
         first.compression_method(),
-        rawzip::CompressionMethod::Deflate
+        rawzip::CompressionMethod::DEFLATE
     );
     let reader = flate2::read::DeflateDecoder::new(entry.reader());
     let mut reader = entry.verifying_reader(reader);
@@ -1241,12 +1241,11 @@ fn oversized_entry_needs_max_central_directory_buffer() {
     let name = "a".repeat(u16::MAX as usize);
     let comment = vec![b'c'; u16::MAX as usize];
     let extra = vec![0u8; u16::MAX as usize - 4];
-
     let mut output = Vec::new();
     let mut writer = ZipArchiveWriter::new(&mut output);
     let (entry, config) = writer
         .new_file(&name)
-        .compression_method(rawzip::CompressionMethod::Store)
+        .compression_method(rawzip::CompressionMethod::STORE)
         .extra_field(ExtraFieldId::new(0xcafe), &extra, rawzip::Header::CENTRAL)
         .unwrap()
         .comment(comment)


### PR DESCRIPTION
The existing `CompressionMethod` has a couple major flaws:

```rust
CompressionMethod::Unknown(8) != CompressionMethod::Deflate
```

Which could be solved with a custom PartialEq, but doesn't that _feel_ wrong?

And there tension between wanting to provide a non-exhaustive enum variants and `CompressionMethod::Unknown`. What does it mean for a non-exhaustive unknown? Since we should expect more compression methods in the future, we need to enforce non-exhaustive for future stability.

So this commit switches the type to a struct with associated constants. This is a soft breaking change as `CompressionMethod::Deflate` is now a deprecated alias of `CompressionMethod::DEFLATE`.

See [`http::StatusCode`](https://docs.rs/http/latest/http/status/struct.StatusCode.html) for inspiration.