### PR TITLE
Preserve trailing slash in directories when normalization required

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -229,6 +229,11 @@ impl ZipFilePath<()> {
             result.push_str(split);
         }
 
+        // Preserve a trailing slash so directory entries remain directories.
+        if s.as_bytes().last() == Some(&b'/') && !result.is_empty() {
+            result.push('/');
+        }
+
         result
     }
 }
@@ -390,6 +395,15 @@ mod tests {
     #[case(b"C:\\hello\\test.txt", "hello/test.txt")]
     #[case(b"C:/hello\\test.txt", "hello/test.txt")]
     #[case(b"C:/hello/test.txt", "hello/test.txt")]
+    #[case(b"foo/bar/", "foo/bar/")]
+    #[case(b"foo\\bar\\", "foo/bar/")]
+    #[case(b"dir//sub/", "dir/sub/")]
+    #[case(b"dir/./", "dir/")]
+    #[case(b"x..y/", "x..y/")]
+    #[case(b"a/b/../", "a/")]
+    #[case(b"dir\\", "dir/")]
+    #[case(b"../", "")]
+    #[case(b"./", "")]
     fn test_zip_path_normalized(#[case] input: &[u8], #[case] expected: &str) {
         assert_eq!(
             ZipFilePath::from_bytes(input)

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1217,6 +1217,16 @@ mod tests {
     }
 
     #[test]
+    fn test_new_dir_slow_path_preserves_trailing_slash() {
+        // A directory name that trips the normalization slow path (here `//`)
+        // must still be recognized as a directory rather than rejected.
+        let mut output = Cursor::new(Vec::new());
+        let mut archive = ZipArchiveWriter::new(&mut output);
+        archive.new_dir("a//b/").create().unwrap();
+        archive.finish().unwrap();
+    }
+
+    #[test]
     fn test_builder_with_offset_and_capacity() {
         let mut output = Cursor::new(Vec::new());
 


### PR DESCRIPTION
When a file system path needed to be normalized, it did not preserve the trailing slash that signalled it's a directory, causing zip writer to fail and for inconsistency.

The following now passes:

```rust
assert!(ZipFilePath::from_str("foo\\bar\\").is_dir());
```