### PR TITLE
Add ZipSliceEntry::local_header accessor

### DIFF
--- a/fuzz/fuzz_targets/fuzz_zip.rs
+++ b/fuzz/fuzz_targets/fuzz_zip.rs
@@ -57,9 +57,9 @@ fn fuzz_reader_zip_archive(data: &[u8], buf: &mut Vec<u8>) -> Result<(), rawzip:
             continue;
         };
 
-        let _local_header = ent
-            .local_header(extra_data_buf)
-            .expect("to be able to parse again");
+        let Ok(_local_header) = ent.local_header(extra_data_buf) else {
+            continue;
+        };
         let _range = ent.compressed_data_range();
         match entry.compression_method() {
             rawzip::CompressionMethod::Store => {
@@ -103,7 +103,8 @@ fn fuzz_slice_zip_archive(data: &[u8]) -> Result<(), rawzip::Error> {
             continue;
         };
 
-        let _extra_fields = ent.extra_fields();
+        let _local_header = ent.local_header();
+        let _extra_fields = _local_header.extra_fields();
         let _range = ent.compressed_data_range();
         match entry.compression_method() {
             rawzip::CompressionMethod::Store => {

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -238,39 +238,38 @@ impl<'a> ZipSliceEntry<'a> {
         (compressed_data_start, compressed_data_end)
     }
 
-    /// Returns an iterator over the extra fields from the local file header.
+    /// Returns the local file header information.
     ///
-    /// See [`ZipLocalFileHeader`] for more details.
-    pub fn extra_fields(&self) -> ExtraFields<'_> {
+    /// This is the single entry point for the entry's file path, extra fields,
+    /// and flags, mirroring [`ZipEntry::local_header`] on the reader-based
+    /// archive.
+    ///
+    /// ```rust
+    /// # use rawzip::{ZipArchive, Error};
+    /// # fn example(data: &[u8]) -> Result<(), Error> {
+    /// let archive = ZipArchive::from_slice(data)?;
+    /// let entry_header = archive.entries().next_entry()?.unwrap();
+    /// let entry = archive.get_entry(entry_header.wayfinder())?;
+    /// let header = entry.local_header();
+    /// let _path = header.file_path();
+    /// let _flags = header.flags();
+    /// for (_id, _field) in header.extra_fields() {}
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn local_header(&self) -> ZipLocalFileHeader<'a> {
         let header =
             ZipLocalFileHeaderFixed::parse(self.data).expect("header has already been parsed");
         let file_name_len = header.file_name_len as usize;
         let extra_field_len = header.extra_field_len as usize;
-        let extra_field_start = ZipLocalFileHeaderFixed::SIZE + file_name_len;
-        let extra_field_end = extra_field_start + extra_field_len;
-        ExtraFields::new(&self.data[extra_field_start..extra_field_end])
-    }
-
-    /// Returns the file path from the local file header.
-    ///
-    /// See [`ZipLocalFileHeader`] for more details.
-    pub fn file_path(&self) -> ZipFilePath<RawPath<'_>> {
-        let header =
-            ZipLocalFileHeaderFixed::parse(self.data).expect("header has already been parsed");
-        let file_name_len = header.file_name_len as usize;
         let filename_start = ZipLocalFileHeaderFixed::SIZE;
         let filename_end = filename_start + file_name_len;
-        ZipFilePath::from_bytes(&self.data[filename_start..filename_end])
-    }
-
-    /// Returns the general purpose bit flags from the local file header.
-    ///
-    /// These may differ from the central directory record's flags. See
-    /// [`EntryFlags`] for the individual flag accessors.
-    pub fn flags(&self) -> EntryFlags {
-        let header =
-            ZipLocalFileHeaderFixed::parse(self.data).expect("header has already been parsed");
-        header.flags
+        let extra_field_end = filename_end + extra_field_len;
+        ZipLocalFileHeader {
+            flags: header.flags,
+            file_path: ZipFilePath::from_bytes(&self.data[filename_start..filename_end]),
+            extra_fields: ExtraFields::new(&self.data[filename_end..extra_field_end]),
+        }
     }
 }
 
@@ -949,7 +948,7 @@ where
 ///
 /// Most ZIP tools use the central directory as authoritative, but access to local
 /// header data is useful for validation, security analysis, and forensic purposes.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ZipLocalFileHeader<'a> {
     flags: EntryFlags,
     file_path: ZipFilePath<RawPath<'a>>,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1095,8 +1095,9 @@ fn test_filename_mismatch_handling() {
 
     let slice_wayfinder = slice_header.wayfinder();
     let slice_entry = slice_archive.get_entry(slice_wayfinder).unwrap();
-    let slice_local_filename = slice_entry.file_path();
-    assert_eq!(slice_local_filename.as_ref(), b"safe_file.txt",);
+
+    let slice_local_header = slice_entry.local_header();
+    assert_eq!(slice_local_header, local_header);
 }
 
 #[test]

--- a/tests/it/modification_time_tests.rs
+++ b/tests/it/modification_time_tests.rs
@@ -375,8 +375,8 @@ fn test_infozip_extended_timestamps_slice() {
     // Get local header extra fields
     let wayfinder = entry.wayfinder();
     let zip_entry = archive.get_entry(wayfinder).unwrap();
-    let local_fields = zip_entry.extra_fields();
-    assert_extend_time_extra_field_difference(entry.extra_fields(), local_fields);
+    let local_header = zip_entry.local_header();
+    assert_extend_time_extra_field_difference(entry.extra_fields(), local_header.extra_fields());
 }
 
 fn assert_extend_time_extra_field_difference(mut central: ExtraFields, mut local: ExtraFields) {

--- a/tests/it/utf8_tests.rs
+++ b/tests/it/utf8_tests.rs
@@ -41,7 +41,10 @@ fn test_filename_utf8_flag(#[case] filename: &str, #[case] should_have_utf8_flag
     let entry = archive.entries().next_entry().unwrap().unwrap();
     assert_eq!(entry.flags().is_utf8(), should_have_utf8_flag);
     let slice_entry = archive.get_entry(entry.wayfinder()).unwrap();
-    assert_eq!(slice_entry.flags().is_utf8(), should_have_utf8_flag);
+    assert_eq!(
+        slice_entry.local_header().flags().is_utf8(),
+        should_have_utf8_flag
+    );
 }
 
 /// Test directory UTF-8 flag behavior with various directory names


### PR DESCRIPTION
Mirror ZipEntry::local_header on the slice-based entry so both archive
types expose a ZipLocalFileHeader. The slice variant needs no buffer and
is infallible since the entire local header is already in memory.

This removes `ZipSliceEntry::{file_path,extra_fields}` for two reasons:

- They become redundant behind `local_header`
- They had too strict of a lifetime. They should have been tied to the
  data, not to the entry.