### PR TITLE
Make central directory CRC authoritative

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -152,22 +152,18 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
             return Err(Error::from(ErrorKind::Eof));
         }
 
-        let (entire_entry, rest) = header.split_at(total_size as usize);
-
-        let expected_crc = if entry.has_data_descriptor {
-            DataDescriptor::parse(rest)?.crc
-        } else {
-            entry.crc
-        };
+        let (entire_entry, descriptor) = header.split_at(total_size as usize);
 
         Ok(ZipSliceEntry {
             data: entire_entry,
             verifier: ZipVerification {
-                crc: expected_crc,
+                crc: entry.crc,
                 uncompressed_size: entry.uncompressed_size_hint(),
             },
             local_header_offset: entry.local_header_offset,
             data_start_offset: header_size,
+            has_data_descriptor: entry.has_data_descriptor,
+            descriptor,
         })
     }
 }
@@ -183,6 +179,8 @@ pub struct ZipSliceEntry<'a> {
     local_header_offset: u64,
     // self.data[self.data_start_offset] is the start of compressed data
     data_start_offset: u32,
+    has_data_descriptor: bool,
+    descriptor: &'a [u8],
 }
 
 impl<'a> ZipSliceEntry<'a> {
@@ -193,11 +191,21 @@ impl<'a> ZipSliceEntry<'a> {
 
     /// Returns a verifier for the CRC and uncompressed size of the entry.
     ///
-    /// Useful when it's more practical to oneshot decompress the data,
-    /// otherwise use [`ZipSliceEntry::verifying_reader`] to stream
-    /// decompression and verification.
+    /// See [`ZipReader::claim_verifier`] for more commentary.
     pub fn claim_verifier(&self) -> ZipVerification {
         self.verifier
+    }
+
+    /// Reads the trailing [`ZipDataDescriptor`] for this entry, if present.
+    pub fn data_descriptor(&self) -> Result<Option<ZipDataDescriptor>, Error> {
+        if !self.has_data_descriptor {
+            return Ok(None);
+        }
+
+        let descriptor = DataDescriptor::parse(self.descriptor)?;
+        Ok(Some(ZipDataDescriptor {
+            crc: descriptor.crc,
+        }))
     }
 
     /// Returns a reader that wraps a decompressor and verify the size and CRC
@@ -206,12 +214,12 @@ impl<'a> ZipSliceEntry<'a> {
     where
         D: std::io::Read,
     {
-        ZipSliceVerifier {
+        ZipSliceVerifier(ZipVerifier {
             reader,
             verifier: self.verifier,
             crc: 0,
             size: 0,
-        }
+        })
     }
 
     /// Returns the byte range of the compressed data within the archive.
@@ -250,41 +258,24 @@ impl<'a> ZipSliceEntry<'a> {
     }
 }
 
-/// Verifies the wrapped reader returns the expected CRC and uncompressed size
+/// Verifies the wrapped reader returns the expected CRC and uncompressed size.
 #[derive(Debug, Clone)]
-pub struct ZipSliceVerifier<D> {
-    reader: D,
-    crc: u32,
-    size: u64,
-    verifier: ZipVerification,
-}
+pub struct ZipSliceVerifier<Decompressor>(ZipVerifier<Decompressor>);
 
-impl<D> ZipSliceVerifier<D> {
-    /// Consumes the `ZipSliceVerifier`, returning the underlying reader.
-    pub fn into_inner(self) -> D {
-        self.reader
+impl<Decompressor> ZipSliceVerifier<Decompressor> {
+    /// Consumes the [`ZipSliceVerifier`], returning the underlying decompressor
+    /// without verifying.
+    pub fn into_inner(self) -> Decompressor {
+        self.0.into_inner()
     }
 }
 
-impl<D> std::io::Read for ZipSliceVerifier<D>
+impl<Decompressor> std::io::Read for ZipSliceVerifier<Decompressor>
 where
-    D: std::io::Read,
+    Decompressor: std::io::Read,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let read = self.reader.read(buf)?;
-        self.crc = crc32_chunk(&buf[..read], self.crc);
-        self.size += read as u64;
-
-        if read == 0 || self.size >= self.verifier.uncompressed_size {
-            self.verifier
-                .valid(ZipVerification {
-                    crc: self.crc,
-                    uncompressed_size: self.size,
-                })
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        }
-
-        Ok(read)
+        self.0.read(buf)
     }
 }
 
@@ -659,7 +650,7 @@ where
 
     /// Returns a reader that wraps a decompressor and verify the size and CRC
     /// of the decompressed data once finished.
-    pub fn verifying_reader<D>(&self, reader: D) -> ZipVerifier<D, &'archive R>
+    pub fn verifying_reader<D>(&self, reader: D) -> ZipVerifier<D>
     where
         D: std::io::Read,
     {
@@ -667,9 +658,10 @@ where
             reader,
             crc: 0,
             size: 0,
-            archive: self.archive.get_ref(),
-            end_offset: self.body_end_offset,
-            wayfinder: self.entry,
+            verifier: ZipVerification {
+                crc: self.entry.crc,
+                uncompressed_size: self.entry.uncompressed_size_hint(),
+            },
         }
     }
 
@@ -835,53 +827,44 @@ impl ZipVerification {
     }
 }
 
-/// Verifies the checksum of the decompressed data matches the checksum listed in the zip
+/// Verifies the checksum of the decompressed data matches the checksum listed
+/// in the central directory.
 #[derive(Debug, Clone)]
-pub struct ZipVerifier<Decompressor, ReaderAt> {
+pub struct ZipVerifier<Decompressor> {
     reader: Decompressor,
     crc: u32,
     size: u64,
-    archive: ReaderAt,
-    end_offset: u64,
-    wayfinder: ZipArchiveEntryWayfinder,
+    verifier: ZipVerification,
 }
 
-impl<Decompressor, ReaderAt> ZipVerifier<Decompressor, ReaderAt> {
-    /// Consumes the [`ZipVerifier`], returning the underlying decompressor.
+impl<Decompressor> ZipVerifier<Decompressor> {
+    /// Consumes the [`ZipVerifier`], returning the underlying decompressor
+    /// without verifying.
     pub fn into_inner(self) -> Decompressor {
         self.reader
     }
 }
 
-impl<Decompressor, Reader> std::io::Read for ZipVerifier<Decompressor, Reader>
+impl<Decompressor> std::io::Read for ZipVerifier<Decompressor>
 where
     Decompressor: std::io::Read,
-    Reader: ReaderAt,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         let read = self.reader.read(buf)?;
         self.crc = crc32_chunk(&buf[..read], self.crc);
         self.size += read as u64;
 
-        if read == 0 || self.size >= self.wayfinder.uncompressed_size_hint() {
-            let crc = if self.wayfinder.has_data_descriptor {
-                DataDescriptor::read_at(&self.archive, self.end_offset).map(|x| x.crc)
-            } else {
-                Ok(self.wayfinder.crc)
-            };
-
-            crc.and_then(|crc| {
-                let expected = ZipVerification {
-                    crc,
-                    uncompressed_size: self.wayfinder.uncompressed_size_hint(),
-                };
-
-                expected.valid(ZipVerification {
+        if read == 0 || self.size >= self.verifier.uncompressed_size {
+            self.verifier
+                .valid(ZipVerification {
                     crc: self.crc,
                     uncompressed_size: self.size,
                 })
-            })
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         }
 
         Ok(read)
@@ -899,27 +882,30 @@ impl<R> ZipReader<R>
 where
     R: ReaderAt,
 {
-    /// Returns an object that can be used to verify the size and checksum of
-    /// inflated data
+    /// Returns the expected data verification of the inflated data.
     ///
-    /// Consumes the reader, so this should be called after all data has been read from the entry.
-    ///
-    /// The function will read the data descriptor if one is expected to exist.
-    pub fn claim_verifier(self) -> Result<ZipVerification, Error> {
-        let expected_size = self.entry.uncompressed_size_hint();
+    /// Rawzip considers the central directory to be authoritative, so this
+    /// returns the CRC and uncompressed size from the central directory. If you
+    /// want to check the data descriptor instead, use
+    /// [`ZipReader::data_descriptor`] to read it.
+    pub fn claim_verifier(&self) -> ZipVerification {
+        ZipVerification {
+            crc: self.entry.crc,
+            uncompressed_size: self.entry.uncompressed_size_hint(),
+        }
+    }
 
-        let expected_crc = if self.entry.has_data_descriptor {
-            let end_offset = self.range_reader.end_offset();
-            let archive = self.range_reader.into_inner();
-            DataDescriptor::read_at(archive, end_offset).map(|x| x.crc)?
-        } else {
-            self.entry.crc
-        };
+    /// Reads the trailing [`ZipDataDescriptor`] for this entry, if present.
+    pub fn data_descriptor(&self) -> Result<Option<ZipDataDescriptor>, Error> {
+        if !self.entry.has_data_descriptor {
+            return Ok(None);
+        }
 
-        Ok(ZipVerification {
-            crc: expected_crc,
-            uncompressed_size: expected_size,
-        })
+        let descriptor =
+            DataDescriptor::read_at(self.range_reader.get_ref(), self.range_reader.end_offset())?;
+        Ok(Some(ZipDataDescriptor {
+            crc: descriptor.crc,
+        }))
     }
 }
 
@@ -962,6 +948,27 @@ impl<'a> ZipLocalFileHeader<'a> {
     /// central directory entry.
     pub fn extra_fields(&self) -> ExtraFields<'a> {
         self.extra_fields
+    }
+}
+
+/// The data descriptor trailing an entry's compressed data.
+///
+/// Obtain one via [`ZipReader::data_descriptor`] or
+/// [`ZipSliceEntry::data_descriptor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZipDataDescriptor {
+    crc: u32,
+}
+
+impl ZipDataDescriptor {
+    /// The CRC32 checksum of the uncompressed data as recorded in the data
+    /// descriptor.
+    ///
+    /// Can be cross-checked against the central directory CRC
+    /// ([`ZipFileHeaderRecord::crc32`]) to detect inconsistent archives.
+    #[inline]
+    pub fn crc(&self) -> u32 {
+        self.crc
     }
 }
 

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -1,0 +1,375 @@
+use flate2::read::DeflateDecoder;
+use rawzip::{
+    CompressionMethod, Error, ErrorKind, RECOMMENDED_BUFFER_SIZE, ReaderAt, ZipArchive,
+    ZipArchiveWriter, ZipReader, ZipVerification,
+};
+use std::io::{self, Cursor, Read, Write};
+
+const CONTENT: &[u8] =
+    b"the quick brown fox jumps over the lazy dog. the quick brown fox jumps over the lazy dog.";
+
+/// Builds an in-memory deflate-compressed zip. The writer always emits a data
+/// descriptor, so this exercises the descriptor-present path.
+fn build_deflate_zip(content: &[u8]) -> Vec<u8> {
+    let mut output = Cursor::new(Vec::new());
+    let mut archive = ZipArchiveWriter::new(&mut output);
+    let (mut entry, config) = archive
+        .new_file("file.txt")
+        .compression_method(CompressionMethod::Deflate)
+        .start()
+        .unwrap();
+    let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
+    let mut writer = config.wrap(encoder);
+    writer.write_all(content).unwrap();
+    let (encoder, descriptor) = writer.finish().unwrap();
+    encoder.finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+    output.into_inner()
+}
+
+/// Offset of the 4-byte CRC field within an entry's central directory record.
+fn central_crc_offset(data: &[u8]) -> usize {
+    let archive = ZipArchive::from_slice(data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    entry.central_directory_offset() as usize + 16
+}
+
+/// Returns the wayfinder for the first entry of a reader-based archive.
+fn first_wayfinder<R: ReaderAt>(archive: &ZipArchive<R>) -> rawzip::ZipArchiveEntryWayfinder {
+    let mut buffer = vec![0u8; RECOMMENDED_BUFFER_SIZE];
+    let mut entries = archive.entries(&mut buffer);
+    entries.next_entry().unwrap().unwrap().wayfinder()
+}
+
+fn corrupt_central_crc(data: &mut [u8]) -> (u32, u32) {
+    let offset = central_crc_offset(data);
+    let original = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+    let corrupted = original ^ 0xffff_ffff;
+    data[offset..offset + 4].copy_from_slice(&corrupted.to_le_bytes());
+    (original, corrupted)
+}
+
+fn corrupt_descriptor_crc(data: &mut [u8]) -> (u32, u32) {
+    let archive = ZipArchive::from_slice(&*data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+    assert_eq!(ent.data_descriptor().unwrap().unwrap().crc(), entry.crc32());
+
+    let (_, compressed_data_end) = ent.compressed_data_range();
+    let descriptor_crc_offset = compressed_data_end as usize + 4;
+    let original = u32::from_le_bytes(
+        data[descriptor_crc_offset..descriptor_crc_offset + 4]
+            .try_into()
+            .unwrap(),
+    );
+    let corrupted = original ^ 0xffff_ffff;
+    data[descriptor_crc_offset..descriptor_crc_offset + 4]
+        .copy_from_slice(&corrupted.to_le_bytes());
+    (original, corrupted)
+}
+
+#[test]
+fn slice_imperative_claim_verifier() {
+    let data = build_deflate_zip(CONTENT);
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let decoder = DeflateDecoder::new(ent.data());
+    let mut crc_reader = flate2::CrcReader::new(decoder);
+    let mut out = Vec::new();
+    io::copy(&mut crc_reader, &mut out).unwrap();
+
+    assert_eq!(out, CONTENT);
+    ent.claim_verifier()
+        .valid(ZipVerification {
+            crc: crc_reader.crc().sum(),
+            uncompressed_size: out.len() as u64,
+        })
+        .unwrap();
+}
+
+#[test]
+fn slice_verifying_reader() {
+    let data = build_deflate_zip(CONTENT);
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let inflater = DeflateDecoder::new(ent.data());
+    let mut verifier = ent.verifying_reader(inflater);
+    let mut out = Vec::new();
+    io::copy(&mut verifier, &mut out).unwrap();
+    assert_eq!(out, CONTENT);
+}
+
+#[test]
+fn reader_imperative_claim_verifier() {
+    let data = build_deflate_zip(CONTENT);
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+
+    let decoder = DeflateDecoder::new(ent.reader());
+    let mut crc_reader = flate2::CrcReader::new(decoder);
+    let mut out = Vec::new();
+    io::copy(&mut crc_reader, &mut out).unwrap();
+    assert_eq!(out, CONTENT);
+
+    let actual = ZipVerification {
+        crc: crc_reader.crc().sum(),
+        uncompressed_size: out.len() as u64,
+    };
+    let zip_reader = crc_reader.into_inner().into_inner();
+    zip_reader.claim_verifier().valid(actual).unwrap();
+}
+
+#[test]
+fn reader_verifying_reader() {
+    let data = build_deflate_zip(CONTENT);
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+
+    let inflater = DeflateDecoder::new(ent.reader());
+    let mut verifier = ent.verifying_reader(inflater);
+    let mut out = Vec::new();
+    io::copy(&mut verifier, &mut out).unwrap();
+    assert_eq!(out, CONTENT);
+}
+
+#[test]
+fn full_read_verifies_without_finish() {
+    let mut data = build_deflate_zip(CONTENT);
+    let (original, corrupted) = corrupt_central_crc(&mut data);
+
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+
+    let mut verifier = ent.verifying_reader(DeflateDecoder::new(ent.data()));
+    let mut buf = vec![0u8; CONTENT.len()];
+    // read_exact of the full size triggers verification on the final read,
+    // surfacing the corrupt central CRC without requiring a terminal method.
+    let err = verifier.read_exact(&mut buf).unwrap_err();
+    assert_invalid_checksum(err, corrupted, original);
+}
+
+struct CustomCrcVerifier<R> {
+    reader: flate2::CrcReader<DeflateDecoder<ZipReader<R>>>,
+    size: u64,
+    verifications: usize,
+}
+
+impl<R: ReaderAt> CustomCrcVerifier<R> {
+    fn new(reader: ZipReader<R>) -> Self {
+        Self {
+            reader: flate2::CrcReader::new(DeflateDecoder::new(reader)),
+            size: 0,
+            verifications: 0,
+        }
+    }
+}
+
+impl<R: ReaderAt> Read for CustomCrcVerifier<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let read = self.reader.read(buf)?;
+        self.size += read as u64;
+
+        let expected = self.reader.get_ref().get_ref().claim_verifier();
+        if read == 0 || self.size >= expected.uncompressed_size {
+            expected
+                .valid(ZipVerification {
+                    crc: self.reader.crc().sum(),
+                    uncompressed_size: self.size,
+                })
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            self.verifications += 1;
+        }
+
+        Ok(read)
+    }
+}
+
+#[test]
+fn custom_crc_verifier_empty_buffer_and_eof_verification() {
+    let data = build_deflate_zip(CONTENT);
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let mut verifier = CustomCrcVerifier::new(ent.reader());
+
+    // An empty target buffer must not be treated as EOF.
+    assert_eq!(verifier.read(&mut []).unwrap(), 0);
+    assert_eq!(verifier.verifications, 0);
+
+    let mut out = Vec::new();
+    io::copy(&mut verifier, &mut out).unwrap();
+    assert_eq!(out, CONTENT);
+    assert_eq!(verifier.verifications, 2);
+
+    // Redundant reads past EOF stay at EOF and run the same verification path.
+    assert_eq!(verifier.read(&mut [0u8; 16]).unwrap(), 0);
+    assert_eq!(verifier.verifications, 3);
+}
+
+#[test]
+fn corrupt_central_crc_rejected() {
+    let mut data = build_deflate_zip(CONTENT);
+    let (original, corrupted) = corrupt_central_crc(&mut data);
+    let read_limit = CONTENT.len() as u64 + 1;
+
+    // Slice verifier.
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+    let verifier = ent.verifying_reader(DeflateDecoder::new(ent.data()));
+    let err = io::copy(&mut verifier.take(read_limit), &mut io::sink()).unwrap_err();
+    assert_invalid_checksum(err, corrupted, original);
+
+    // Reader verifier.
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let verifier = ent.verifying_reader(DeflateDecoder::new(ent.reader()));
+    let err = io::copy(&mut verifier.take(read_limit), &mut io::sink()).unwrap_err();
+    assert_invalid_checksum(err, corrupted, original);
+}
+
+fn assert_invalid_checksum(err: io::Error, expected: u32, actual: u32) {
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    let zip_error = err.into_inner().unwrap().downcast::<Error>().unwrap();
+    match zip_error.kind() {
+        ErrorKind::InvalidChecksum {
+            expected: e,
+            actual: a,
+        } => {
+            assert_eq!(*e, expected);
+            assert_eq!(*a, actual);
+        }
+        other => panic!("expected InvalidChecksum, got {other:?}"),
+    }
+}
+
+#[test]
+fn data_descriptor_present_for_streamed_entry() {
+    let data = build_deflate_zip(CONTENT);
+
+    // Slice path.
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    assert!(entry.has_data_descriptor());
+    let central_crc = entry.crc32();
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+    let dd = ent.data_descriptor().unwrap().expect("descriptor present");
+    assert_eq!(dd.crc(), central_crc);
+
+    // Reader path.
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let reader = ent.reader();
+    let dd = reader
+        .data_descriptor()
+        .unwrap()
+        .expect("descriptor present");
+    assert_eq!(dd.crc(), central_crc);
+}
+
+#[test]
+fn data_descriptor_absent_for_non_streamed_entry() {
+    let data = std::fs::read("assets/crc32-not-streamed.zip").unwrap();
+
+    // Slice path.
+    let archive = ZipArchive::from_slice(&data).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    assert!(!entry.has_data_descriptor());
+    let ent = archive.get_entry(entry.wayfinder()).unwrap();
+    assert!(ent.data_descriptor().unwrap().is_none());
+
+    // Reader path.
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let reader = ent.reader();
+    assert!(reader.data_descriptor().unwrap().is_none());
+}
+
+struct DescriptorVerifier<R> {
+    reader: flate2::CrcReader<DeflateDecoder<ZipReader<R>>>,
+    size: u64,
+    verified: bool,
+}
+
+impl<R: ReaderAt> DescriptorVerifier<R> {
+    fn new(reader: ZipReader<R>) -> Self {
+        Self {
+            reader: flate2::CrcReader::new(DeflateDecoder::new(reader)),
+            size: 0,
+            verified: false,
+        }
+    }
+}
+
+impl<R: ReaderAt> Read for DescriptorVerifier<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let read = self.reader.read(buf)?;
+        self.size += read as u64;
+
+        let zr = self.reader.get_ref().get_ref();
+        let expected = zr.claim_verifier();
+        if !self.verified && (read == 0 || self.size >= expected.uncompressed_size) {
+            if let Some(descriptor) = zr
+                .data_descriptor()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            {
+                expected
+                    .valid(ZipVerification {
+                        crc: descriptor.crc(),
+                        uncompressed_size: expected.uncompressed_size,
+                    })
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            }
+
+            expected
+                .valid(ZipVerification {
+                    crc: self.reader.crc().sum(),
+                    uncompressed_size: self.size,
+                })
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            self.verified = true;
+        }
+
+        Ok(read)
+    }
+}
+
+#[test]
+fn descriptor_cross_check_rejects_descriptor_divergence() {
+    let mut data = build_deflate_zip(CONTENT);
+    // Corrupt only the descriptor CRC; the central directory and data stay correct.
+    let (original, corrupted) = corrupt_descriptor_crc(&mut data);
+    let read_limit = CONTENT.len() as u64 + 1;
+
+    // The default verifying_reader keys off the central directory and succeeds.
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let wayfinder = first_wayfinder(&archive);
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let verifier = ent.verifying_reader(DeflateDecoder::new(ent.reader()));
+    io::copy(&mut verifier.take(read_limit), &mut io::sink()).unwrap();
+
+    // The cross-checking verifier rejects the descriptor/central mismatch.
+    let ent = archive.get_entry(wayfinder).unwrap();
+    let mut verifier = DescriptorVerifier::new(ent.reader());
+    let err = io::copy(&mut verifier, &mut io::sink()).unwrap_err();
+    assert_invalid_checksum(err, original, corrupted);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
 
+mod crc_tests;
 mod encryption_tests;
 mod extra_data_zip_tests;
 mod extra_fields_test;
@@ -819,65 +820,6 @@ fn errors_eq(a: &Error, b: &ErrorKind) -> bool {
     }
 }
 
-#[test]
-fn catch_incorrect_crc_without_data_descriptor() {
-    let mut data = std::fs::read("assets/crc32-not-streamed.zip").unwrap();
-
-    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
-    let mut entries = archive.entries();
-    let entry = entries.next_entry().unwrap().unwrap();
-    assert!(!entry.has_data_descriptor());
-
-    // Mutate the central directory CRC to be incorrect
-    let crc_offset = entry.central_directory_offset() as usize + 16;
-    let original_crc = u32::from_le_bytes(data[crc_offset..crc_offset + 4].try_into().unwrap());
-    let corrupted_crc = original_crc ^ 0xffff_ffff;
-    data[crc_offset..crc_offset + 4].copy_from_slice(&corrupted_crc.to_le_bytes());
-
-    // Ensure that the slice verifier rejects the bad CRC
-    let archive = ZipArchive::from_slice(data.as_slice()).unwrap();
-    let mut entries = archive.entries();
-    let entry = entries.next_entry().unwrap().unwrap();
-    let ent = archive.get_entry(entry.wayfinder()).unwrap();
-
-    let mut verifier = ent.verifying_reader(ent.data());
-    let slice_result = std::io::copy(&mut verifier, &mut std::io::sink());
-
-    let err = slice_result.unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
-    let source = err.into_inner().unwrap();
-    let zip_error = source.downcast::<rawzip::Error>().unwrap();
-    match zip_error.kind() {
-        ErrorKind::InvalidChecksum { expected, actual } => {
-            assert_eq!(*expected, corrupted_crc);
-            assert_eq!(*actual, original_crc);
-        }
-        other => panic!("expected InvalidChecksum error, got {other:?}"),
-    }
-
-    // Ensure that the reader verifier rejects the bad CRC
-    let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
-    let archive = ZipArchive::from_seekable(Cursor::new(data), &mut buffer).unwrap();
-    let mut entries = archive.entries(&mut buffer);
-    let entry = entries.next_entry().unwrap().unwrap();
-    let ent = archive.get_entry(entry.wayfinder()).unwrap();
-
-    let mut verifier = ent.verifying_reader(ent.reader());
-    let reader_result = std::io::copy(&mut verifier, &mut std::io::sink());
-
-    let err = reader_result.unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
-    let source = err.into_inner().unwrap();
-    let zip_error = source.downcast::<rawzip::Error>().unwrap();
-    match zip_error.kind() {
-        ErrorKind::InvalidChecksum { expected, actual } => {
-            assert_eq!(*expected, corrupted_crc);
-            assert_eq!(*actual, original_crc);
-        }
-        other => panic!("expected InvalidChecksum error, got {other:?}"),
-    }
-}
-
 /// This test is to ensure that the ZipArchive can be created from a Vec<u8>
 #[test]
 fn zip_integration_tests_vec() {
@@ -1252,38 +1194,4 @@ fn test_ff_optimized_jar_reader() {
     let count = std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
     assert_eq!(first.uncompressed_size_hint(), count);
     entries.next_entry().unwrap_err();
-}
-
-#[test]
-fn test_custom_crc_reader() {
-    // Tests that consumers can "bring their own CRC" if they want
-    let f = File::open("assets/test.zip").unwrap();
-    let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
-    let archive = ZipArchive::from_file(f, &mut buf).unwrap();
-    let mut entries = archive.entries(&mut buf);
-    let entry = entries.next_entry().unwrap().unwrap();
-    assert_eq!(
-        entry.compression_method(),
-        rawzip::CompressionMethod::Deflate
-    );
-    let wayfinder = entry.wayfinder();
-    let ent = archive.get_entry(wayfinder).unwrap();
-    let zip_reader = ent.reader();
-    let decoder = flate2::read::DeflateDecoder::new(zip_reader);
-
-    let mut reader = flate2::CrcReader::new(decoder);
-    std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
-
-    let actual_crc = reader.crc().sum();
-    let size = reader.get_ref().total_out();
-    let zip_reader = reader.into_inner().into_inner();
-    let verification = zip_reader.claim_verifier().unwrap();
-    assert_ne!(actual_crc, 0, "CRC should not be zero");
-    assert_eq!(verification.crc, actual_crc);
-    verification
-        .valid(rawzip::ZipVerification {
-            crc: actual_crc,
-            uncompressed_size: size,
-        })
-        .unwrap();
 }


### PR DESCRIPTION
I sampled 10 zip file libraries to see how many that are oriented around the central directory (aka seekable) use the data descriptor's crc value as the sole value for crc validation like rawzip. 0.

The closest are the libraries that cross validate the data descriptor crc with the central directory and report a mismatched crc value on differences (libzip, go's archive/zip, logged in libarchive)

Other libraries (python zipfile, zip2 crate, minizip-ng, and 7-zip) do not cross validate and only use the central directory crc.

This commit transitions rawzip to adopt the latter philosophy, where the central directory crc is used for validation.

For those that want cross validation, a `data_descriptor` function has been exposed.

Changelog:

- **Breaking**: `ZipReader::claim_verifier` now borrows self and is infallible
- **Breaking**: `ZipVerifier` dropped its `ReaderAt` type parameter
- Built-in CRC/size verification is now central-directory authoritative and never reads the trailing data descriptor
- Expose `ZipDataDescriptor` and `data_descriptor()` functions

Closes #123 
Closes #127 