### PR TITLE
Add EntryFlags accessor for general purpose bit flags

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,6 +1,7 @@
 use crate::crc::crc32_chunk;
 use crate::errors::{Error, ErrorKind};
 use crate::extra_fields::{ExtraFieldId, ExtraFields};
+use crate::headers::EntryFlags;
 use crate::mode::{
     CREATOR_FAT, CREATOR_MACOS, CREATOR_NTFS, CREATOR_UNIX, CREATOR_VFAT, EntryMode,
     msdos_mode_to_file_mode, unix_mode_to_file_mode,
@@ -255,6 +256,16 @@ impl<'a> ZipSliceEntry<'a> {
         let filename_start = ZipLocalFileHeaderFixed::SIZE;
         let filename_end = filename_start + file_name_len;
         ZipFilePath::from_bytes(&self.data[filename_start..filename_end])
+    }
+
+    /// Returns the general purpose bit flags from the local file header.
+    ///
+    /// These may differ from the central directory record's flags. See
+    /// [`EntryFlags`] for the individual flag accessors.
+    pub fn flags(&self) -> EntryFlags {
+        let header =
+            ZipLocalFileHeaderFixed::parse(self.data).expect("header has already been parsed");
+        header.flags
     }
 }
 
@@ -786,6 +797,7 @@ where
 
         let (filename_data, extra_field_data) = variable_data.split_at(file_name_len);
         Ok(ZipLocalFileHeader {
+            flags: local_header_fixed.flags,
             file_path: ZipFilePath::from_bytes(filename_data),
             extra_fields: ExtraFields::new(extra_field_data),
         })
@@ -929,14 +941,25 @@ where
 /// header data is useful for validation, security analysis, and forensic purposes.
 #[derive(Debug)]
 pub struct ZipLocalFileHeader<'a> {
+    flags: EntryFlags,
     file_path: ZipFilePath<RawPath<'a>>,
     extra_fields: ExtraFields<'a>,
 }
 
 impl<'a> ZipLocalFileHeader<'a> {
+    /// Returns the general purpose bit flags from the local file header.
+    ///
+    /// These may differ from the central directory record's flags. See
+    /// [`EntryFlags`] for the individual flag accessors.
+    #[inline]
+    pub fn flags(&self) -> EntryFlags {
+        self.flags
+    }
+
     /// Returns the file path from the local file header.
     ///
     /// This may differ from the central directory file path.
+    #[inline]
     pub fn file_path(&self) -> ZipFilePath<RawPath<'a>> {
         self.file_path
     }
@@ -946,6 +969,7 @@ impl<'a> ZipLocalFileHeader<'a> {
     /// Extra fields in the local header may differ from those in the central directory.
     /// The local header may contain additional or different metadata compared to the
     /// central directory entry.
+    #[inline]
     pub fn extra_fields(&self) -> ExtraFields<'a> {
         self.extra_fields
     }
@@ -1386,7 +1410,7 @@ pub struct ZipFileHeaderRecord<'a> {
     signature: u32,
     version_made_by: u16,
     version_needed: u16,
-    flags: u16,
+    flags: EntryFlags,
     compression_method: CompressionMethodId,
     last_mod_time: u16,
     last_mod_date: u16,
@@ -1504,16 +1528,12 @@ impl<'a> ZipFileHeaderRecord<'a> {
         self.file_name.is_dir()
     }
 
-    /// Returns true if the entry has a data descriptor that follows its
-    /// compressed data.
+    /// Returns the general purpose bit flags for this entry.
     ///
-    /// From the spec (4.3.9.1):
-    ///
-    /// > This descriptor MUST exist if bit 3 of the general purpose bit flag is
-    /// > set
+    /// See [`EntryFlags`] for the individual flag accessors.
     #[inline]
-    pub fn has_data_descriptor(&self) -> bool {
-        self.flags & 0x08 != 0
+    pub fn flags(&self) -> EntryFlags {
+        self.flags
     }
 
     /// Describes where the file's data is located within the archive.
@@ -1523,7 +1543,7 @@ impl<'a> ZipFileHeaderRecord<'a> {
             uncompressed_size: self.uncompressed_size,
             compressed_size: self.compressed_size,
             local_header_offset: self.local_header_offset,
-            has_data_descriptor: self.has_data_descriptor(),
+            has_data_descriptor: self.flags().has_data_descriptor(),
             crc: self.crc32,
         }
     }
@@ -1728,7 +1748,7 @@ impl ZipArchiveEntryWayfinder {
 pub(crate) struct ZipLocalFileHeaderFixed {
     pub(crate) signature: u32,
     pub(crate) version_needed: u16,
-    pub(crate) flags: u16,
+    pub(crate) flags: EntryFlags,
     pub(crate) compression_method: CompressionMethodId,
     pub(crate) last_mod_time: u16,
     pub(crate) last_mod_date: u16,
@@ -1751,7 +1771,7 @@ impl ZipLocalFileHeaderFixed {
         let result = ZipLocalFileHeaderFixed {
             signature: le_u32(&data[0..4]),
             version_needed: le_u16(&data[4..6]),
-            flags: le_u16(&data[6..8]),
+            flags: EntryFlags::new(le_u16(&data[6..8])),
             compression_method: CompressionMethodId(le_u16(&data[8..10])),
             last_mod_time: le_u16(&data[10..12]),
             last_mod_date: le_u16(&data[12..14]),
@@ -1784,7 +1804,7 @@ impl ZipLocalFileHeaderFixed {
         let mut buffer = [0u8; 30];
         buffer[..4].copy_from_slice(&self.signature.to_le_bytes());
         buffer[4..6].copy_from_slice(&self.version_needed.to_le_bytes());
-        buffer[6..8].copy_from_slice(&self.flags.to_le_bytes());
+        buffer[6..8].copy_from_slice(&self.flags.bits().to_le_bytes());
         buffer[8..10].copy_from_slice(&self.compression_method.0.to_le_bytes());
         buffer[10..12].copy_from_slice(&self.last_mod_time.to_le_bytes());
         buffer[12..14].copy_from_slice(&self.last_mod_date.to_le_bytes());
@@ -1803,7 +1823,7 @@ pub(crate) struct ZipFileHeaderFixed {
     pub signature: u32,
     pub version_made_by: u16,
     pub version_needed: u16,
-    pub flags: u16,
+    pub flags: EntryFlags,
     pub compression_method: CompressionMethodId,
     pub last_mod_time: u16,
     pub last_mod_date: u16,
@@ -1845,7 +1865,7 @@ impl ZipFileHeaderFixed {
             signature: le_u32(&data[0..4]),
             version_made_by: le_u16(&data[4..6]),
             version_needed: le_u16(&data[6..8]),
-            flags: le_u16(&data[8..10]),
+            flags: EntryFlags::new(le_u16(&data[8..10])),
             compression_method: CompressionMethodId(le_u16(&data[10..12])),
             last_mod_time: le_u16(&data[12..14]),
             last_mod_date: le_u16(&data[14..16]),
@@ -1900,7 +1920,7 @@ impl ZipFileHeaderFixed {
         buffer[0..4].copy_from_slice(&self.signature.to_le_bytes());
         buffer[4..6].copy_from_slice(&self.version_made_by.to_le_bytes());
         buffer[6..8].copy_from_slice(&self.version_needed.to_le_bytes());
-        buffer[8..10].copy_from_slice(&self.flags.to_le_bytes());
+        buffer[8..10].copy_from_slice(&self.flags.bits().to_le_bytes());
         buffer[10..12].copy_from_slice(&self.compression_method.0.to_le_bytes());
         buffer[12..14].copy_from_slice(&self.last_mod_time.to_le_bytes());
         buffer[14..16].copy_from_slice(&self.last_mod_date.to_le_bytes());

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -77,6 +77,69 @@ impl std::ops::BitAndAssign for Header {
     }
 }
 
+/// The general purpose bit flags of a ZIP entry.
+///
+/// (§ 4.4.4). Only the bits with a fixed, method-independent meaning are
+/// surfaced as named accessors. Use [`EntryFlags::bits`] to inspect the raw
+/// value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntryFlags(u16);
+
+impl EntryFlags {
+    const ENCRYPTED: u16 = 1 << 0;
+    const DATA_DESCRIPTOR: u16 = 1 << 3;
+    const STRONG_ENCRYPTION: u16 = 1 << 6;
+    const LANGUAGE_ENCODING: u16 = 1 << 11;
+    const MASKED: u16 = 1 << 13;
+
+    #[inline]
+    pub(crate) const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    /// The raw 16-bit general purpose bit flag value.
+    ///
+    /// Use this to inspect the method-dependent bits 1 and 2, or any of the
+    /// reserved bits not surfaced by the named accessors.
+    #[inline]
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// Bit 0: the entry's data is encrypted.
+    #[inline]
+    pub const fn is_encrypted(self) -> bool {
+        self.0 & Self::ENCRYPTED != 0
+    }
+
+    /// Bit 3: the crc-32, compressed size, and uncompressed size are zeroed in
+    /// the local header, with the correct values stored in a data descriptor
+    /// that follows the compressed data.
+    #[inline]
+    pub const fn has_data_descriptor(self) -> bool {
+        self.0 & Self::DATA_DESCRIPTOR != 0
+    }
+
+    /// Bit 6: the entry uses strong encryption.
+    #[inline]
+    pub const fn has_strong_encryption(self) -> bool {
+        self.0 & Self::STRONG_ENCRYPTION != 0
+    }
+
+    /// Bit 11 (EFS): the file name and comment are encoded as UTF-8.
+    #[inline]
+    pub const fn is_utf8(self) -> bool {
+        self.0 & Self::LANGUAGE_ENCODING != 0
+    }
+
+    /// Bit 13: selected values in the local header are masked because the
+    /// central directory is encrypted.
+    #[inline]
+    pub const fn is_masked(self) -> bool {
+        self.0 & Self::MASKED != 0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod writer;
 pub use archive::*;
 pub use crc::crc32;
 pub use errors::{Error, ErrorKind};
-pub use headers::Header;
+pub use headers::{EntryFlags, Header};
 pub use locator::*;
 pub use mode::EntryMode;
 pub use reader_at::{FileReader, RangeReader, ReaderAt};

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,8 +1,8 @@
 use crate::{
     CENTRAL_HEADER_SIGNATURE, CompressionMethod, DataDescriptor,
     END_OF_CENTRAL_DIR_LOCATOR_SIGNATURE, END_OF_CENTRAL_DIR_SIGNATURE64,
-    END_OF_CENTRAL_DIR_SIGNAUTRE_BYTES, Error, Header, ZipFileHeaderFixed, ZipLocalFileHeaderFixed,
-    crc,
+    END_OF_CENTRAL_DIR_SIGNAUTRE_BYTES, EntryFlags, Error, Header, ZipFileHeaderFixed,
+    ZipLocalFileHeaderFixed, crc,
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
     mode::CREATOR_UNIX,
@@ -568,7 +568,7 @@ where
         let header = ZipLocalFileHeaderFixed {
             signature: ZipLocalFileHeaderFixed::SIGNATURE,
             version_needed: 20,
-            flags,
+            flags: EntryFlags::new(flags),
             compression_method: compression_method.as_id(),
             last_mod_time: dos_time,
             last_mod_date: dos_date,
@@ -780,7 +780,7 @@ where
                 signature: CENTRAL_HEADER_SIGNATURE,
                 version_made_by,
                 version_needed,
-                flags: file.flags,
+                flags: EntryFlags::new(file.flags),
                 compression_method: file.compression_method.as_id(),
                 last_mod_time: dos_time,
                 last_mod_date: dos_date,

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -263,7 +263,7 @@ fn data_descriptor_present_for_streamed_entry() {
     // Slice path.
     let archive = ZipArchive::from_slice(&data).unwrap();
     let entry = archive.entries().next_entry().unwrap().unwrap();
-    assert!(entry.has_data_descriptor());
+    assert!(entry.flags().has_data_descriptor());
     let central_crc = entry.crc32();
     let ent = archive.get_entry(entry.wayfinder()).unwrap();
     let dd = ent.data_descriptor().unwrap().expect("descriptor present");
@@ -288,7 +288,7 @@ fn data_descriptor_absent_for_non_streamed_entry() {
     // Slice path.
     let archive = ZipArchive::from_slice(&data).unwrap();
     let entry = archive.entries().next_entry().unwrap().unwrap();
-    assert!(!entry.has_data_descriptor());
+    assert!(!entry.flags().has_data_descriptor());
     let ent = archive.get_entry(entry.wayfinder()).unwrap();
     assert!(ent.data_descriptor().unwrap().is_none());
 

--- a/tests/it/encryption_tests.rs
+++ b/tests/it/encryption_tests.rs
@@ -147,6 +147,8 @@ fn decrypt_winzip_aes_entry(path: &str, expected_strength: u8, expected_vendor_v
 
     assert_eq!(entry.file_path().as_ref(), b"test.txt");
     assert_eq!(entry.compression_method(), CompressionMethod::Aes);
+    assert!(entry.flags().is_encrypted());
+    assert!(!entry.flags().has_strong_encryption());
 
     let central_metadata = find_aes_extra_field(entry.extra_fields());
     assert_eq!(central_metadata, expected_metadata);
@@ -174,6 +176,7 @@ fn decrypt_winzip_aes_entry(path: &str, expected_strength: u8, expected_vendor_v
         .unwrap();
     let local_metadata = find_aes_extra_field(local_header.extra_fields());
     assert_eq!(local_metadata, expected_metadata);
+    assert!(local_header.flags().is_encrypted());
 
     let ciphertext_len = compressed_size
         .checked_sub((salt_len + PASSWORD_VERIFIER_LEN + AUTH_CODE_LEN) as u64)

--- a/tests/it/utf8_tests.rs
+++ b/tests/it/utf8_tests.rs
@@ -34,6 +34,14 @@ fn test_filename_utf8_flag(#[case] filename: &str, #[case] should_have_utf8_flag
         utf8_flag_present, should_have_utf8_flag,
         "UTF-8 flag mismatch for filename '{filename}': expected {should_have_utf8_flag}, got {utf8_flag_present}"
     );
+
+    // The same flag must be reachable through the public accessor on both the
+    // central directory record and the local header.
+    let archive = rawzip::ZipArchive::from_slice(&output).unwrap();
+    let entry = archive.entries().next_entry().unwrap().unwrap();
+    assert_eq!(entry.flags().is_utf8(), should_have_utf8_flag);
+    let slice_entry = archive.get_entry(entry.wayfinder()).unwrap();
+    assert_eq!(slice_entry.flags().is_utf8(), should_have_utf8_flag);
 }
 
 /// Test directory UTF-8 flag behavior with various directory names


### PR DESCRIPTION
This removes `ZipFileHeaderRecord::has_data_descriptor` in favor of this more general mechanism to be consistent, so this is a breaking change but the ecosystem impact was measured to be minimal.