### PR TITLE
Seal TimeZoneMarker trait

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -110,8 +110,14 @@ pub struct Utc;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Local;
 
-/// Trait for timezone markers
-pub trait TimeZoneMarker {
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Utc {}
+    impl Sealed for super::Local {}
+}
+
+/// Trait for timezone markers (sealed).
+pub trait TimeZoneMarker: sealed::Sealed {
     fn timezone() -> TimeZone;
 }
 


### PR DESCRIPTION
There is zero reasons for downstream usages to implement this trait, so seal it off.