### PR TITLE
Add MAX_CENTRAL_DIRECTORY_RECORD_SIZE for sizing buffers

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -16,14 +16,30 @@ use std::io::{Read, Seek, Write};
 pub(crate) const END_OF_CENTRAL_DIR_SIGNATURE64: u32 = 0x06064b50;
 pub(crate) const END_OF_CENTRAL_DIR_LOCATOR_SIGNATURE: u32 = 0x07064b50;
 pub(crate) const CENTRAL_HEADER_SIGNATURE: u32 = 0x02014b50;
+
 /// The recommended buffer size to use when reading from a zip file.
 ///
-/// This buffer size was chosen as it can hold an entire central directory
-/// record as the spec states (4.4.10):
+/// A buffer of this size should hold an entire central directory record as the
+/// spec recommends (4.4.10):
 ///
 /// > the combined length of any directory and these three fields SHOULD NOT
 /// > generally exceed 65,535 bytes.
+///
+/// However, a pathological central directory record can still exceed this size
+/// causing [`ErrorKind::BufferTooSmall`] to be returned when parsing entries.
+/// [`MAX_CENTRAL_DIRECTORY_RECORD_SIZE`] can be used to avoid this error.
 pub const RECOMMENDED_BUFFER_SIZE: usize = 1 << 16;
+
+/// The maximum size in bytes of a single central directory file header record.
+///
+/// - Fixed-size: 46 bytes
+/// - file name, comment, and extra data can each be up to 65,535 bytes
+///
+/// A buffer of this size guarantees [`ErrorKind::BufferTooSmall`] can never
+/// occur. At roughly 192 KiB, it is still small enough to be reasonable for
+/// most use cases.
+pub const MAX_CENTRAL_DIRECTORY_RECORD_SIZE: usize =
+    ZipFileHeaderFixed::SIZE + 3 * u16::MAX as usize;
 
 /// Represents a Zip archive that operates on an in-memory data.
 ///

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,7 +1,7 @@
 use quickcheck_macros::quickcheck;
 use rawzip::extra_fields::ExtraFieldId;
 use rawzip::time::{LocalDateTime, UtcDateTime, ZipDateTimeKind};
-use rawzip::{Error, ErrorKind, ZipArchive};
+use rawzip::{Error, ErrorKind, ZipArchive, ZipArchiveWriter};
 use std::fs::File;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
@@ -1192,4 +1192,52 @@ fn test_ff_optimized_jar_reader() {
     let count = std::io::copy(&mut reader, &mut std::io::sink()).unwrap();
     assert_eq!(first.uncompressed_size_hint(), count);
     entries.next_entry().unwrap_err();
+}
+
+/// An archive whose single entry has the largest central directory record the
+/// format permits.
+#[test]
+fn oversized_entry_needs_max_central_directory_buffer() {
+    let name = "a".repeat(u16::MAX as usize);
+    let comment = vec![b'c'; u16::MAX as usize];
+    let extra = vec![0u8; u16::MAX as usize - 4];
+
+    let mut output = Vec::new();
+    let mut writer = ZipArchiveWriter::new(&mut output);
+    let (entry, config) = writer
+        .new_file(&name)
+        .compression_method(rawzip::CompressionMethod::Store)
+        .extra_field(ExtraFieldId::new(0xcafe), &extra, rawzip::Header::CENTRAL)
+        .unwrap()
+        .comment(comment)
+        .start()
+        .unwrap();
+    let (entry, descriptor) = config.wrap(entry).finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    writer.finish().unwrap();
+
+    // A buffer sized to RECOMMENDED_BUFFER_SIZE is too small
+    let mut small = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let archive = rawzip::ZipLocator::new()
+        .locate_in_reader(output.as_slice(), &mut small, output.len() as u64)
+        .unwrap();
+    let mut entries = archive.entries(&mut small);
+    let err = entries.next_entry().unwrap_err();
+    assert!(matches!(err.kind(), rawzip::ErrorKind::BufferTooSmall));
+
+    // A buffer sized to MAX_CENTRAL_DIRECTORY_RECORD_SIZE parses it.
+    let mut large = vec![0u8; rawzip::MAX_CENTRAL_DIRECTORY_RECORD_SIZE];
+    let archive = rawzip::ZipLocator::new()
+        .locate_in_reader(output.as_slice(), &mut large, output.len() as u64)
+        .unwrap();
+    let mut entries = archive.entries(&mut large);
+    let entry = entries.next_entry().unwrap().expect("entry present");
+    assert_eq!(entry.file_path().as_bytes().len(), u16::MAX as usize);
+    assert!(entries.next_entry().unwrap().is_none());
+
+    // The slice reader has no problem parsing it either
+    let slice_archive = ZipArchive::from_slice(&output).unwrap();
+    let mut slice_entries = slice_archive.entries();
+    let slice_entry = slice_entries.next_entry().unwrap().expect("entry present");
+    assert_eq!(slice_entry.file_path().as_bytes().len(), u16::MAX as usize);
 }


### PR DESCRIPTION
Document the absolute maximum central directory record size and expose a constant so callers can size a buffer accordingly (if they care about these zip entries)