### PR TITLE
Allow verbatim file name writes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,6 @@ pub use errors::{Error, ErrorKind};
 pub use headers::{EntryFlags, Header};
 pub use locator::*;
 pub use mode::EntryMode;
+pub use path::EntryName;
 pub use reader_at::{FileReader, RangeReader, ReaderAt};
 pub use writer::*;

--- a/src/path.rs
+++ b/src/path.rs
@@ -263,28 +263,19 @@ where
     }
 }
 
-impl<R> ZipFilePath<R>
-where
-    R: AsRef<str>,
-{
-    /// Determines if the path requires UTF-8 encoding based on CP-437 compatibility.
-    ///
-    /// Returns `true` if the path contains characters that cannot be represented in CP-437
-    /// (the default ZIP encoding), requiring the UTF-8 flag to be set in the ZIP file.
-    pub(crate) fn needs_utf8_encoding(&self) -> bool {
-        for ch in self.data.as_ref().chars() {
-            let code_point = ch as u32;
+pub(crate) fn str_needs_utf8(s: &str) -> bool {
+    for ch in s.chars() {
+        let code_point = ch as u32;
 
-            // Forbid 0x7e (~) and 0x5c (\) since EUC-KR and Shift-JIS replace those
-            // characters with localized currency and overline characters.
-            // Also forbid control characters (< 0x20) and characters above 0x7d.
-            if !(0x20..=0x7d).contains(&code_point) || code_point == 0x5c {
-                return true;
-            }
+        // Forbid 0x7e (~) and 0x5c (\) since EUC-KR and Shift-JIS replace those
+        // characters with localized currency and overline characters.
+        // Also forbid control characters (< 0x20) and characters above 0x7d.
+        if !(0x20..=0x7d).contains(&code_point) || code_point == 0x5c {
+            return true;
         }
-
-        false
     }
+
+    false
 }
 
 impl<'a> ZipFilePath<RawPath<'a>> {
@@ -367,6 +358,89 @@ impl ZipFilePath<NormalizedPathBuf> {
     #[inline]
     pub fn as_str(&self) -> &str {
         self.data.0.as_ref()
+    }
+}
+
+/// Controls how an entry name is written.
+///
+/// - [`EntryName::conformant`] normalizes UTF-8 text and sets the
+///   [`EntryFlags::is_utf8`](crate::EntryFlags::is_utf8) flag when needed.
+/// - [`EntryName::verbatim`] writes uninterpreted bytes without that flag.
+///
+/// # Examples
+///
+/// ```rust
+/// use rawzip::EntryName;
+///
+/// // A UTF-8 path, normalized on write.
+/// let name = EntryName::conformant("docs/readme.txt");
+///
+/// // Exact bytes, no normalization, no UTF-8 flag.
+/// let name = EntryName::verbatim(b"odd\x05name");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryName<'a>(pub(crate) EntryNameInner<'a>);
+
+/// The private name-writing policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EntryNameInner<'a> {
+    /// Normalize UTF-8 text and set utf-8 flag when needed.
+    Conformant(Cow<'a, str>),
+    /// UTF-8 text already normalized by the reader.
+    Normalized(Cow<'a, str>),
+    /// Uninterpreted bytes without utf-8 flag.
+    Verbatim(Cow<'a, [u8]>),
+}
+
+impl<'a> EntryName<'a> {
+    /// Creates a normalized UTF-8 name, setting utf-8 flag when needed.
+    #[inline]
+    pub fn conformant<S: Into<Cow<'a, str>>>(name: S) -> Self {
+        EntryName(EntryNameInner::Conformant(name.into()))
+    }
+
+    /// Creates an exact, uninterpreted name without utf-8 flag.
+    #[inline]
+    pub fn verbatim<B: Into<Cow<'a, [u8]>>>(name: B) -> Self {
+        EntryName(EntryNameInner::Verbatim(name.into()))
+    }
+}
+
+impl<'a, T> From<&'a T> for EntryName<'a>
+where
+    T: AsRef<str> + ?Sized,
+{
+    #[inline]
+    fn from(value: &'a T) -> Self {
+        EntryName::conformant(value.as_ref())
+    }
+}
+
+impl<'a> From<String> for EntryName<'a> {
+    #[inline]
+    fn from(value: String) -> Self {
+        EntryName::conformant(value)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for EntryName<'a> {
+    #[inline]
+    fn from(value: Cow<'a, str>) -> Self {
+        EntryName::conformant(value)
+    }
+}
+
+impl<'a> From<ZipFilePath<NormalizedPath<'a>>> for EntryName<'a> {
+    #[inline]
+    fn from(value: ZipFilePath<NormalizedPath<'a>>) -> Self {
+        EntryName(EntryNameInner::Normalized(value.data.0))
+    }
+}
+
+impl<'a> From<ZipFilePath<NormalizedPathBuf>> for EntryName<'a> {
+    #[inline]
+    fn from(value: ZipFilePath<NormalizedPathBuf>) -> Self {
+        EntryName(EntryNameInner::Normalized(Cow::Owned(value.data.0)))
     }
 }
 
@@ -457,7 +531,7 @@ mod tests {
     fn test_needs_utf8_encoding(#[case] input: &str, #[case] expected: bool) {
         let path = ZipFilePath::from_str(input);
         assert_eq!(
-            path.needs_utf8_encoding(),
+            str_needs_utf8(path.as_str()),
             expected,
             "Failed for input: {input}"
         );

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,7 +6,7 @@ use crate::{
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
     mode::CREATOR_UNIX,
-    path::{NormalizedPath, ZipFilePath},
+    path::{EntryName, EntryNameInner, ZipFilePath, str_needs_utf8},
     time::{DosDateTime, UtcDateTime},
 };
 use std::io::{self, Write};
@@ -24,6 +24,34 @@ const FLAG_UTF8_ENCODING: u16 = 0x800; // bit 11: UTF-8 encoding flag (EFS)
 const ZIP64_THRESHOLD_FILE_SIZE: u64 = u32::MAX as u64;
 const ZIP64_THRESHOLD_OFFSET: u64 = u32::MAX as u64;
 const ZIP64_THRESHOLD_ENTRIES: usize = u16::MAX as usize;
+
+fn with_resolved_entry_name<T>(
+    name: EntryName<'_>,
+    trim_trailing_slash: bool,
+    write: impl FnOnce(&[u8], bool) -> T,
+) -> T {
+    match name.0 {
+        EntryNameInner::Conformant(name) => {
+            let name = if trim_trailing_slash {
+                name.trim_end_matches('/')
+            } else {
+                &name
+            };
+            let path = ZipFilePath::from_str(name);
+            let name = path.as_str();
+            write(name.as_bytes(), str_needs_utf8(name))
+        }
+        EntryNameInner::Normalized(name) => {
+            let name = if trim_trailing_slash {
+                name.trim_end_matches('/')
+            } else {
+                &name
+            };
+            write(name.as_bytes(), str_needs_utf8(name))
+        }
+        EntryNameInner::Verbatim(name) => write(&name, false),
+    }
+}
 
 #[derive(Debug)]
 struct CountWriter<W> {
@@ -264,7 +292,7 @@ impl Crc32Option {
 #[derive(Debug)]
 pub struct ZipFileBuilder<'archive, 'name, W> {
     archive: &'archive mut ZipArchiveWriter<W>,
-    name: &'name str,
+    name: EntryName<'name>,
     compression_method: CompressionMethod,
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
@@ -521,7 +549,7 @@ where
 #[derive(Debug)]
 pub struct ZipDirBuilder<'a, W> {
     archive: &'a mut ZipArchiveWriter<W>,
-    name: &'a str,
+    name: EntryName<'a>,
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
     extra_fields: ExtraFieldsContainer,
@@ -597,7 +625,7 @@ where
     /// Writes a local file header with filtered extra fields.
     fn write_local_header(
         &mut self,
-        file_path: &ZipFilePath<NormalizedPath>,
+        name_bytes: &[u8],
         flags: u16,
         compression_method: CompressionMethod,
         options: &mut ZipEntryOptions,
@@ -630,12 +658,12 @@ where
             crc32: 0, // must be zero if data descriptor is used (4.4.4)
             compressed_size: 0,
             uncompressed_size: 0,
-            file_name_len: file_path.len() as u16,
+            file_name_len: name_bytes.len() as u16,
             extra_field_len: options.extra_fields.local_size,
         };
 
         header.write(&mut self.writer)?;
-        self.writer.write_all(file_path.as_ref().as_bytes())?;
+        self.writer.write_all(name_bytes)?;
         options
             .extra_fields
             .write_extra_fields(&mut self.writer, Header::LOCAL)?;
@@ -644,7 +672,7 @@ where
 
     /// Creates a builder for adding a new directory to the archive.
     ///
-    /// The name of the directory must end with a `/`.
+    /// The name must end with `/`, including for [`EntryName::verbatim`].
     ///
     /// # Example
     ///
@@ -658,10 +686,10 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
-    pub fn new_dir<'a>(&'a mut self, name: &'a str) -> ZipDirBuilder<'a, W> {
+    pub fn new_dir<'a>(&'a mut self, name: impl Into<EntryName<'a>>) -> ZipDirBuilder<'a, W> {
         ZipDirBuilder {
             archive: self,
-            name,
+            name: name.into(),
             modification_time: None,
             unix_permissions: None,
             extra_fields: ExtraFieldsContainer::new(),
@@ -674,38 +702,43 @@ where
     /// The name of the directory must end with a `/`.
     fn new_dir_with_options(
         &mut self,
-        name: &str,
+        name: EntryName<'_>,
+        options: ZipEntryOptions,
+    ) -> Result<(), Error> {
+        with_resolved_entry_name(name, false, |name, needs_utf8| {
+            self.write_dir_entry(name, needs_utf8, options)
+        })
+    }
+
+    /// Writes a directory using resolved name bytes.
+    fn write_dir_entry(
+        &mut self,
+        name_bytes: &[u8],
+        needs_utf8: bool,
         mut options: ZipEntryOptions,
     ) -> Result<(), Error> {
-        let file_path = ZipFilePath::from_str(name);
-        if !file_path.is_dir() {
+        if !ZipFilePath::from_bytes(name_bytes).is_dir() {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "not a directory".to_string(),
             }));
         }
 
-        if file_path.len() > u16::MAX as usize {
+        if name_bytes.len() > u16::MAX as usize {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "directory name too long".to_string(),
             }));
         }
 
         let local_header_offset = self.writer.count();
-        let mut flags = 0u16;
-        if file_path.needs_utf8_encoding() {
-            flags |= FLAG_UTF8_ENCODING;
-        } else {
-            flags &= !FLAG_UTF8_ENCODING;
-        }
+        let flags = if needs_utf8 { FLAG_UTF8_ENCODING } else { 0 };
 
         // Store the name bytes in the central buffer
-        let name_bytes = file_path.as_ref().as_bytes();
         let name_len = name_bytes.len() as u16;
         self.file_names.extend_from_slice(name_bytes);
 
         let file_comment_len = comment_len(&options.file_comment)?;
 
-        self.write_local_header(&file_path, flags, CompressionMethod::Store, &mut options)?;
+        self.write_local_header(name_bytes, flags, CompressionMethod::Store, &mut options)?;
 
         self.file_comments.extend_from_slice(&options.file_comment);
 
@@ -729,6 +762,8 @@ where
 
     /// Creates a builder for adding a new file to the archive.
     ///
+    /// A trailing `/` is stripped unless the name is [`EntryName::verbatim`].
+    ///
     /// # Example
     ///
     /// ```rust
@@ -746,10 +781,13 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
-    pub fn new_file<'name>(&mut self, name: &'name str) -> ZipFileBuilder<'_, 'name, W> {
+    pub fn new_file<'name>(
+        &mut self,
+        name: impl Into<EntryName<'name>>,
+    ) -> ZipFileBuilder<'_, 'name, W> {
         ZipFileBuilder {
             archive: self,
-            name,
+            name: name.into(),
             compression_method: CompressionMethod::Store,
             modification_time: None,
             unix_permissions: None,
@@ -763,12 +801,22 @@ where
     /// Adds a new file to the archive with options (internal method).
     fn new_file_with_options(
         &mut self,
-        name: &str,
+        name: EntryName<'_>,
+        options: ZipEntryOptions,
+    ) -> Result<ZipEntryWriter<'_, W>, Error> {
+        with_resolved_entry_name(name, true, |name, needs_utf8| {
+            self.write_file_entry(name, needs_utf8, options)
+        })
+    }
+
+    /// Writes a file using resolved name bytes.
+    fn write_file_entry(
+        &mut self,
+        name_bytes: &[u8],
+        needs_utf8: bool,
         mut options: ZipEntryOptions,
     ) -> Result<ZipEntryWriter<'_, W>, Error> {
-        let file_path = ZipFilePath::from_str(name.trim_end_matches('/'));
-
-        if file_path.len() > u16::MAX as usize {
+        if name_bytes.len() > u16::MAX as usize {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "file name too long".to_string(),
             }));
@@ -776,23 +824,20 @@ where
 
         let local_header_offset = self.writer.count();
         let mut flags = FLAG_DATA_DESCRIPTOR;
-        if file_path.needs_utf8_encoding() {
+        if needs_utf8 {
             flags |= FLAG_UTF8_ENCODING;
-        } else {
-            flags &= !FLAG_UTF8_ENCODING;
         }
         if options.encrypted {
             flags |= FLAG_ENCRYPTED;
         }
 
         // Store the name bytes in the central buffer
-        let name_bytes = file_path.as_ref().as_bytes();
         let name_len = name_bytes.len() as u16;
         self.file_names.extend_from_slice(name_bytes);
 
         let file_comment_len = comment_len(&options.file_comment)?;
 
-        self.write_local_header(&file_path, flags, options.compression_method, &mut options)?;
+        self.write_local_header(name_bytes, flags, options.compression_method, &mut options)?;
 
         self.file_comments.extend_from_slice(&options.file_comment);
 

--- a/tests/it/entry_name_tests.rs
+++ b/tests/it/entry_name_tests.rs
@@ -1,0 +1,123 @@
+use rawzip::{EntryName, ZipArchive, ZipArchiveWriter};
+use std::io::Write;
+
+/// Writes one file and returns the archive.
+fn write_one<'n>(name: impl Into<EntryName<'n>>) -> Vec<u8> {
+    let mut output = Vec::new();
+    let mut archive = ZipArchiveWriter::new(&mut output);
+    let (mut entry, config) = archive.new_file(name).start().unwrap();
+    let mut writer = config.wrap(&mut entry);
+    writer.write_all(b"content").unwrap();
+    let (_, descriptor) = writer.finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+    output
+}
+
+#[test]
+fn borrowed_str_reference_is_an_entry_name() {
+    let name = "file.txt";
+    let output = write_one(&name);
+    let archive = ZipArchive::from_slice(&output).unwrap();
+    let entry = archive.entries().next().unwrap().unwrap();
+
+    assert_eq!(entry.file_path().as_ref(), b"file.txt");
+}
+
+/// Reads the first entry's raw name.
+fn first_entry_name(zip_data: &[u8]) -> Vec<u8> {
+    let archive = ZipArchive::from_slice(zip_data).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    entry.file_path().as_bytes().to_vec()
+}
+
+fn first_entry_is_utf8(zip_data: &[u8]) -> bool {
+    let archive = ZipArchive::from_slice(zip_data).unwrap();
+    let mut entries = archive.entries();
+    entries.next_entry().unwrap().unwrap().flags().is_utf8()
+}
+
+/// Verbatim Shift-JIS remains byte-exact with the UTF-8 flag cleared.
+#[test]
+fn verbatim_shift_jis_roundtrip() {
+    // Shift-JIS "ソ.txt"; build at runtime to avoid a literal lint.
+    let mut raw = vec![0x83u8, 0x5c];
+    raw.extend_from_slice(b".txt");
+    assert!(std::str::from_utf8(&raw).is_err());
+
+    let output = write_one(EntryName::verbatim(raw.as_slice()));
+
+    assert_eq!(
+        first_entry_name(&output),
+        raw,
+        "bytes must be preserved exactly"
+    );
+    assert!(!first_entry_is_utf8(&output));
+}
+
+/// Verbatim data does not infer UTF-8 from valid bytes.
+#[test]
+fn verbatim_valid_utf8_no_flag() {
+    let raw = "日本.txt".as_bytes();
+    let output = write_one(EntryName::verbatim(raw));
+
+    assert_eq!(first_entry_name(&output), raw);
+    assert!(!first_entry_is_utf8(&output));
+}
+
+/// Conformant non-ASCII names set the UTF-8 flag.
+#[test]
+fn conformant_non_ascii_sets_flag() {
+    let output = write_one(EntryName::conformant("日本.txt"));
+    assert_eq!(first_entry_name(&output), "日本.txt".as_bytes());
+    assert!(first_entry_is_utf8(&output));
+}
+
+/// String names retain traversal normalization.
+#[test]
+fn conformant_traversal_collapses_to_root() {
+    let output = write_one("../../etc/passwd");
+    assert_eq!(first_entry_name(&output), b"etc/passwd");
+}
+
+/// Reader-normalized names can be written directly.
+#[test]
+fn normalized_skip_arm_roundtrip() {
+    // Build an entry requiring normalization.
+    let source = write_one(EntryName::verbatim(b"dir/../safe.txt".as_slice()));
+    let src_archive = ZipArchive::from_slice(&source).unwrap();
+    let mut entries = src_archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+    let safe = entry.file_path().try_normalize().unwrap();
+    assert_eq!(safe.as_str(), "safe.txt");
+
+    // Write the normalized path directly.
+    let output = write_one(safe);
+    assert_eq!(first_entry_name(&output), b"safe.txt");
+}
+
+/// Files and directories accept owned names.
+#[test]
+fn owned_names_accepted() {
+    let mut output = Vec::new();
+    let mut archive = ZipArchiveWriter::new(&mut output);
+    archive.new_dir(String::from("d/")).create().unwrap();
+    let (mut entry, config) = archive.new_file(String::from("f.txt")).start().unwrap();
+    let mut writer = config.wrap(&mut entry);
+    writer.write_all(b"x").unwrap();
+    let (_, descriptor) = writer.finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+
+    let archive = ZipArchive::from_slice(&output).unwrap();
+    let mut entries = archive.entries();
+    let names: Vec<_> = std::iter::from_fn(|| {
+        entries
+            .next_entry()
+            .unwrap()
+            .map(|e| e.file_path().as_bytes().to_vec())
+    })
+    .collect();
+    assert_eq!(names, vec![b"d/".to_vec(), b"f.txt".to_vec()]);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 mod crc_tests;
 mod encryption_tests;
+mod entry_name_tests;
 mod extra_data_zip_tests;
 mod extra_fields_test;
 mod false_sentinel_tests;


### PR DESCRIPTION
Forcing UTF-8 file names and normalization when creating a zip file is an artificial limitation.

Now one can write raw bytes with `EntryName::verbatim(b"my-bstr")`.