### PR TITLE
Add last modified dos accessor to central and local headers

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -8,7 +8,7 @@ use crate::mode::{
 };
 use crate::path::{RawPath, ZipFilePath};
 use crate::reader_at::{FileReader, MutexReader, RangeReader, ReaderAt, ReaderAtExt};
-use crate::time::{ZipDateTimeKind, extract_best_timestamp};
+use crate::time::{DosDateTime, ZipDateTimeKind, extract_best_timestamp};
 use crate::utils::{le_u16, le_u32, le_u64};
 use crate::{EndOfCentralDirectory, EndOfCentralDirectoryRecordFixed, ZipLocator};
 use std::io::{Read, Seek, Write};
@@ -283,6 +283,8 @@ impl<'a> ZipSliceEntry<'a> {
         let extra_field_end = filename_end + extra_field_len;
         ZipLocalFileHeader {
             flags: header.flags,
+            last_mod_time: header.last_mod_time,
+            last_mod_date: header.last_mod_date,
             file_path: ZipFilePath::from_bytes(&self.data[filename_start..filename_end]),
             extra_fields: ExtraFields::new(&self.data[filename_end..extra_field_end]),
         }
@@ -818,6 +820,8 @@ where
         let (filename_data, extra_field_data) = variable_data.split_at(file_name_len);
         Ok(ZipLocalFileHeader {
             flags: local_header_fixed.flags,
+            last_mod_time: local_header_fixed.last_mod_time,
+            last_mod_date: local_header_fixed.last_mod_date,
             file_path: ZipFilePath::from_bytes(filename_data),
             extra_fields: ExtraFields::new(extra_field_data),
         })
@@ -967,6 +971,8 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ZipLocalFileHeader<'a> {
     flags: EntryFlags,
+    last_mod_time: u16,
+    last_mod_date: u16,
     file_path: ZipFilePath<RawPath<'a>>,
     extra_fields: ExtraFields<'a>,
 }
@@ -987,6 +993,15 @@ impl<'a> ZipLocalFileHeader<'a> {
     #[inline]
     pub fn file_path(&self) -> ZipFilePath<RawPath<'a>> {
         self.file_path
+    }
+
+    /// Returns the raw MS-DOS modification timestamp from the local file header.
+    ///
+    /// This may differ from the central directory record's
+    /// [`last_modified_dos`](ZipFileHeaderRecord::last_modified_dos).
+    #[inline]
+    pub fn last_modified_dos(&self) -> DosDateTime {
+        DosDateTime::new(self.last_mod_time, self.last_mod_date)
     }
 
     /// Returns an iterator over the extra fields from the local file header.
@@ -1706,6 +1721,17 @@ impl<'a> ZipFileHeaderRecord<'a> {
     #[inline]
     pub fn last_modified(&self) -> ZipDateTimeKind {
         extract_best_timestamp(self.extra_fields(), self.last_mod_time, self.last_mod_date)
+    }
+
+    /// Returns the raw MS-DOS modification timestamp stored in the central
+    /// directory record.
+    ///
+    /// Unlike [`last_modified`](Self::last_modified), this is the raw value from
+    /// the header, and ignores any higher-resolution Extended Timestamp
+    /// extra field.
+    #[inline]
+    pub fn last_modified_dos(&self) -> DosDateTime {
+        DosDateTime::new(self.last_mod_time, self.last_mod_date)
     }
 
     /// Returns the file mode information extracted from the external file attributes.

--- a/src/time.rs
+++ b/src/time.rs
@@ -532,10 +532,42 @@ impl DosDateTime {
         raw_second.min(58)
     }
 
-    /// Returns the packed time and date components as (time, date).
+    /// Returns the raw packed MS-DOS time word (bits 15-11: hour, 10-5: minute,
+    /// 4-0: second/2).
+    ///
+    /// This is the unparsed on-disk value; use [`hour`](Self::hour) and friends
+    /// for decoded components.
+    ///
+    /// ```
+    /// use rawzip::time::{DosDateTime, UtcDateTime};
+    ///
+    /// let dt = UtcDateTime::from_components(2023, 6, 15, 14, 30, 44, 0).unwrap();
+    /// let dos = DosDateTime::from(&dt);
+    /// // hour << 11 | minute << 5 | second / 2
+    /// assert_eq!(dos.packed_time(), (14 << 11) | (30 << 5) | 22);
+    /// ```
     #[must_use]
-    pub(crate) const fn into_parts(self) -> (u16, u16) {
-        (self.time, self.date)
+    pub const fn packed_time(&self) -> u16 {
+        self.time
+    }
+
+    /// Returns the raw packed MS-DOS date word (bits 15-9: year-1980, 8-5:
+    /// month, 4-0: day).
+    ///
+    /// This is the unparsed on-disk value; use [`year`](Self::year) and friends
+    /// for decoded components.
+    ///
+    /// ```
+    /// use rawzip::time::{DosDateTime, UtcDateTime};
+    ///
+    /// let dt = UtcDateTime::from_components(2023, 6, 15, 14, 30, 44, 0).unwrap();
+    /// let dos = DosDateTime::from(&dt);
+    /// // (year - 1980) << 9 | month << 5 | day
+    /// assert_eq!(dos.packed_date(), (43 << 9) | (6 << 5) | 15);
+    /// ```
+    #[must_use]
+    pub const fn packed_date(&self) -> u16 {
+        self.date
     }
 }
 
@@ -776,15 +808,13 @@ mod tests {
         // Test normal conversion
         let zip_dt = utc_from_components(2023, 6, 15, 14, 30, 45, 0);
         let dos_dt: DosDateTime = (&zip_dt).into();
-        let (dos_time, dos_date) = dos_dt.into_parts();
-        let dos_dt_check = DosDateTime::new(dos_time, dos_date);
 
-        assert_eq!(dos_dt_check.year(), 2023);
-        assert_eq!(dos_dt_check.month(), 6);
-        assert_eq!(dos_dt_check.day(), 15);
-        assert_eq!(dos_dt_check.hour(), 14);
-        assert_eq!(dos_dt_check.minute(), 30);
-        assert_eq!(dos_dt_check.second(), 44); // Rounded down to even second
+        assert_eq!(dos_dt.year(), 2023);
+        assert_eq!(dos_dt.month(), 6);
+        assert_eq!(dos_dt.day(), 15);
+        assert_eq!(dos_dt.hour(), 14);
+        assert_eq!(dos_dt.minute(), 30);
+        assert_eq!(dos_dt.second(), 44); // Rounded down to even second
     }
 
     #[test]
@@ -792,34 +822,26 @@ mod tests {
         // Test year before DOS range (should saturate to 1980)
         let zip_dt_before = utc_from_components(1979, 6, 15, 14, 30, 45, 0);
         let dos_dt: DosDateTime = (&zip_dt_before).into();
-        let (dos_time, dos_date) = dos_dt.into_parts();
-        let dos_dt_check = DosDateTime::new(dos_time, dos_date);
-        assert_eq!(dos_dt_check.year(), 1980); // Saturated to minimum
-        assert_eq!(dos_dt_check.month(), 6);
-        assert_eq!(dos_dt_check.day(), 15);
+        assert_eq!(dos_dt.year(), 1980); // Saturated to minimum
+        assert_eq!(dos_dt.month(), 6);
+        assert_eq!(dos_dt.day(), 15);
 
         // Test year way before DOS range
         let zip_dt_way_before = utc_from_components(1800, 1, 1, 0, 0, 0, 0);
         let dos_dt2: DosDateTime = (&zip_dt_way_before).into();
-        let (dos_time2, dos_date2) = dos_dt2.into_parts();
-        let dos_dt2_check = DosDateTime::new(dos_time2, dos_date2);
-        assert_eq!(dos_dt2_check.year(), 1980); // Saturated to minimum
+        assert_eq!(dos_dt2.year(), 1980); // Saturated to minimum
 
         // Test year after DOS range (should saturate to 2107)
         let zip_dt_after = utc_from_components(2108, 6, 15, 14, 30, 45, 0);
         let dos_dt3: DosDateTime = (&zip_dt_after).into();
-        let (dos_time3, dos_date3) = dos_dt3.into_parts();
-        let dos_dt3_check = DosDateTime::new(dos_time3, dos_date3);
-        assert_eq!(dos_dt3_check.year(), 2107); // Saturated to maximum
-        assert_eq!(dos_dt3_check.month(), 6);
-        assert_eq!(dos_dt3_check.day(), 15);
+        assert_eq!(dos_dt3.year(), 2107); // Saturated to maximum
+        assert_eq!(dos_dt3.month(), 6);
+        assert_eq!(dos_dt3.day(), 15);
 
         // Test year way after DOS range
         let zip_dt_way_after = utc_from_components(3000, 12, 31, 23, 59, 59, 0);
         let dos_dt4: DosDateTime = (&zip_dt_way_after).into();
-        let (dos_time4, dos_date4) = dos_dt4.into_parts();
-        let dos_dt4_check = DosDateTime::new(dos_time4, dos_date4);
-        assert_eq!(dos_dt4_check.year(), 2107); // Saturated to maximum
+        assert_eq!(dos_dt4.year(), 2107); // Saturated to maximum
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -606,7 +606,10 @@ where
         let (dos_time, dos_date) = options
             .modification_time
             .as_ref()
-            .map(|dt| DosDateTime::from(dt).into_parts())
+            .map(|dt| {
+                let dos = DosDateTime::from(dt);
+                (dos.packed_time(), dos.packed_date())
+            })
             .unwrap_or((0, 0));
 
         if let Some(datetime) = options.modification_time.as_ref() {
@@ -847,7 +850,10 @@ where
             let (dos_time, dos_date) = file
                 .modification_time
                 .as_ref()
-                .map(|dt| DosDateTime::from(dt).into_parts())
+                .map(|dt| {
+                    let dos = DosDateTime::from(dt);
+                    (dos.packed_time(), dos.packed_date())
+                })
                 .unwrap_or((0, 0));
 
             let header = ZipFileHeaderFixed {

--- a/tests/it/modification_time_tests.rs
+++ b/tests/it/modification_time_tests.rs
@@ -401,3 +401,50 @@ fn assert_extend_time_extra_field_difference(mut central: ExtraFields, mut local
         "Local header should have 9 bytes (mod + access times) and have richer timestamp data than central directory"
     );
 }
+
+#[test]
+fn test_last_modified_dos_raw_packed_fields() {
+    let datetime = UtcDateTime::from_components(2023, 6, 15, 14, 30, 45, 0).unwrap();
+    let mut output = Vec::new();
+
+    {
+        let mut archive = ZipArchiveWriter::new(&mut output);
+        let (mut entry, config) = archive
+            .new_file("test.txt")
+            .last_modified(datetime)
+            .start()
+            .unwrap();
+        let mut writer = config.wrap(&mut entry);
+        writer.write_all(b"Hello, world!").unwrap();
+        let (_, descriptor) = writer.finish().unwrap();
+        entry.finish(descriptor).unwrap();
+        archive.finish().unwrap();
+    }
+
+    let archive = ZipArchive::from_slice(&output).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+
+    let dos = entry.last_modified_dos();
+
+    // Decoded components. DOS seconds have 2-second precision, so 45 -> 44.
+    assert_eq!(dos.year(), 2023);
+    assert_eq!(dos.month(), 6);
+    assert_eq!(dos.day(), 15);
+    assert_eq!(dos.hour(), 14);
+    assert_eq!(dos.minute(), 30);
+    assert_eq!(dos.second(), 44);
+
+    // Raw packed words, matching the on-disk bit layout:
+    //   date = (year - 1980) << 9 | month << 5 | day
+    //   time = hour << 11 | minute << 5 | second / 2
+    assert_eq!(dos.packed_date(), ((2023 - 1980) << 9) | (6 << 5) | 15);
+    assert_eq!(dos.packed_time(), (14 << 11) | (30 << 5) | (45 / 2));
+
+    // The local file header carries the same raw DOS timestamp, which a
+    // streaming reader can read without consulting the central directory.
+    let local = archive.get_entry(entry.wayfinder()).unwrap().local_header();
+    let local_dos = local.last_modified_dos();
+    assert_eq!(local_dos.packed_date(), dos.packed_date());
+    assert_eq!(local_dos.packed_time(), dos.packed_time());
+}


### PR DESCRIPTION
There are use cases where direct access to the dos time in the headers is important (like computing the check byte for zipcrypto before decrypting everything)

The current  `last_modified` leverages extra fields to return the "best" timestamp and would thus obscure this raw value use case.