### PR TITLE
Fail CI on rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo build --all-targets --verbose
-    - run: cargo doc --verbose
+    - run: cargo doc --no-deps --verbose
+      env:
+        RUSTDOCFLAGS: "-D warnings"
     - run: cargo test --verbose --all
 
   # stripped down version of CI to test the MSRV.


### PR DESCRIPTION
Add RUSTDOCFLAGS=-D warnings to the cargo doc step so broken intra-doc links and other doc warnings fail the build.