### PR TITLE
Expose local-header flags and DOS time on ZipEntryWriter

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -478,7 +478,7 @@ impl ZipDateTime<Local> {
 ///
 /// MS-DOS timestamps are stored as packed 16-bit values for date and time,
 /// with a limited range from 1980 to 2107 and 2-second precision for seconds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct DosDateTime {
     time: u16,
     date: u16,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -602,15 +602,11 @@ where
         compression_method: CompressionMethod,
         options: &mut ZipEntryOptions,
     ) -> Result<(), Error> {
-        // Get DOS timestamp from options or use 0 as default
-        let (dos_time, dos_date) = options
+        let dos = options
             .modification_time
             .as_ref()
-            .map(|dt| {
-                let dos = DosDateTime::from(dt);
-                (dos.packed_time(), dos.packed_date())
-            })
-            .unwrap_or((0, 0));
+            .map(DosDateTime::from)
+            .unwrap_or_default();
 
         if let Some(datetime) = options.modification_time.as_ref() {
             let unix_time = datetime.to_unix().max(0) as u32;
@@ -629,8 +625,8 @@ where
             version_needed: 20,
             flags: EntryFlags::new(flags),
             compression_method: compression_method.as_id(),
-            last_mod_time: dos_time,
-            last_mod_date: dos_date,
+            last_mod_time: dos.packed_time(),
+            last_mod_date: dos.packed_date(),
             crc32: 0, // must be zero if data descriptor is used (4.4.4)
             compressed_size: 0,
             uncompressed_size: 0,
@@ -847,14 +843,11 @@ where
             let version_made_by_hi = file.unix_permissions.map(|_| CREATOR_UNIX).unwrap_or(0);
             let version_made_by = (version_made_by_hi << 8) | version_needed;
 
-            let (dos_time, dos_date) = file
+            let dos = file
                 .modification_time
                 .as_ref()
-                .map(|dt| {
-                    let dos = DosDateTime::from(dt);
-                    (dos.packed_time(), dos.packed_date())
-                })
-                .unwrap_or((0, 0));
+                .map(DosDateTime::from)
+                .unwrap_or_default();
 
             let header = ZipFileHeaderFixed {
                 signature: CENTRAL_HEADER_SIGNATURE,
@@ -862,8 +855,8 @@ where
                 version_needed,
                 flags: EntryFlags::new(file.flags),
                 compression_method: file.compression_method.as_id(),
-                last_mod_time: dos_time,
-                last_mod_date: dos_date,
+                last_mod_time: dos.packed_time(),
+                last_mod_date: dos.packed_date(),
                 crc32: file.crc,
                 compressed_size: file.compressed_size.min(ZIP64_THRESHOLD_FILE_SIZE) as u32,
                 uncompressed_size: file.uncompressed_size.min(ZIP64_THRESHOLD_FILE_SIZE) as u32,
@@ -989,6 +982,24 @@ impl<'a, W> ZipEntryWriter<'a, W> {
     /// See [`ZipArchiveWriter::stream_offset`] for more information.
     pub fn stream_offset(&self) -> u64 {
         self.inner.stream_offset()
+    }
+
+    /// Returns the general purpose bit flags written to this entry's local
+    /// header.
+    pub fn flags(&self) -> EntryFlags {
+        EntryFlags::new(self.flags)
+    }
+
+    /// Returns the MS-DOS modification time as actually stored in this entry's
+    /// local header.
+    ///
+    /// Mirrors [`ZipFileHeaderRecord::last_modified_dos`](crate::ZipFileHeaderRecord::last_modified_dos)
+    /// on the reader side.
+    pub fn last_modified_dos(&self) -> DosDateTime {
+        self.modification_time
+            .as_ref()
+            .map(DosDateTime::from)
+            .unwrap_or_default()
     }
 
     /// Finishes writing the file entry.

--- a/tests/it/modification_time_tests.rs
+++ b/tests/it/modification_time_tests.rs
@@ -79,6 +79,11 @@ fn test_no_modification_time_defaults_to_zero() {
     {
         let mut archive = ZipArchiveWriter::new(&mut output);
         let (mut entry, config) = archive.new_file("test.txt").start().unwrap();
+
+        // With no modification time, the writer stores a zeroed DOS timestamp.
+        assert_eq!(entry.last_modified_dos().packed_time(), 0);
+        assert_eq!(entry.last_modified_dos().packed_date(), 0);
+
         let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();
@@ -414,6 +419,12 @@ fn test_last_modified_dos_raw_packed_fields() {
             .last_modified(datetime)
             .start()
             .unwrap();
+
+        assert!(entry.flags().has_data_descriptor());
+        let written = entry.last_modified_dos();
+        assert_eq!(written.packed_date(), ((2023 - 1980) << 9) | (6 << 5) | 15);
+        assert_eq!(written.packed_time(), (14 << 11) | (30 << 5) | (45 / 2));
+
         let mut writer = config.wrap(&mut entry);
         writer.write_all(b"Hello, world!").unwrap();
         let (_, descriptor) = writer.finish().unwrap();


### PR DESCRIPTION
Add ZipEntryWriter::flags() and last_modified_dos() so callers can read back what the writer actually stored in the local header.

For those that want to build a ZipCrypto encryption implementation, exposing these values is particularly important for embedding the checkbyte.