### PR TITLE
Rename EntryName to EntryPath

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,6 @@ pub use errors::{Error, ErrorKind};
 pub use headers::{EntryFlags, Header};
 pub use locator::*;
 pub use mode::EntryMode;
-pub use path::EntryName;
+pub use path::EntryPath;
 pub use reader_at::{FileReader, RangeReader, ReaderAt};
 pub use writer::*;

--- a/src/path.rs
+++ b/src/path.rs
@@ -383,29 +383,32 @@ impl ZipFilePath<NormalizedPathBuf> {
     }
 }
 
-/// Controls how an entry name is written.
+/// Controls how an entry path is written to the ZIP file name field.
 ///
-/// - [`EntryName::conformant`] normalizes UTF-8 text and sets the
+/// ZIP calls this header field the "file name", but the value may include a
+/// relative path such as `dir/file.txt`.
+///
+/// - [`EntryPath::conformant`] normalizes UTF-8 text and sets the
 ///   [`EntryFlags::is_utf8`](crate::EntryFlags::is_utf8) flag when needed.
-/// - [`EntryName::verbatim`] writes uninterpreted bytes without that flag.
+/// - [`EntryPath::verbatim`] writes uninterpreted bytes without that flag.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use rawzip::EntryName;
+/// use rawzip::EntryPath;
 ///
 /// // A UTF-8 path, normalized on write.
-/// let name = EntryName::conformant("docs/readme.txt");
+/// let path = EntryPath::conformant("docs/readme.txt");
 ///
 /// // Exact bytes, no normalization, no UTF-8 flag.
-/// let name = EntryName::verbatim(b"odd\x05name");
+/// let path = EntryPath::verbatim(b"odd\x05name");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EntryName<'a>(pub(crate) EntryNameInner<'a>);
+pub struct EntryPath<'a>(pub(crate) EntryPathInner<'a>);
 
-/// The private name-writing policy.
+/// The private path-writing policy.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum EntryNameInner<'a> {
+pub(crate) enum EntryPathInner<'a> {
     /// Normalize UTF-8 text and set utf-8 flag when needed.
     Conformant(Cow<'a, str>),
     /// UTF-8 text already normalized by the reader.
@@ -414,55 +417,55 @@ pub(crate) enum EntryNameInner<'a> {
     Verbatim(Cow<'a, [u8]>),
 }
 
-impl<'a> EntryName<'a> {
-    /// Creates a normalized UTF-8 name, setting utf-8 flag when needed.
+impl<'a> EntryPath<'a> {
+    /// Creates a normalized UTF-8 path, setting utf-8 flag when needed.
     #[inline]
-    pub fn conformant<S: Into<Cow<'a, str>>>(name: S) -> Self {
-        EntryName(EntryNameInner::Conformant(name.into()))
+    pub fn conformant<S: Into<Cow<'a, str>>>(path: S) -> Self {
+        EntryPath(EntryPathInner::Conformant(path.into()))
     }
 
-    /// Creates an exact, uninterpreted name without utf-8 flag.
+    /// Creates an exact, uninterpreted path without utf-8 flag.
     #[inline]
-    pub fn verbatim<B: Into<Cow<'a, [u8]>>>(name: B) -> Self {
-        EntryName(EntryNameInner::Verbatim(name.into()))
+    pub fn verbatim<B: Into<Cow<'a, [u8]>>>(path: B) -> Self {
+        EntryPath(EntryPathInner::Verbatim(path.into()))
     }
 }
 
-impl<'a, T> From<&'a T> for EntryName<'a>
+impl<'a, T> From<&'a T> for EntryPath<'a>
 where
     T: AsRef<str> + ?Sized,
 {
     #[inline]
     fn from(value: &'a T) -> Self {
-        EntryName::conformant(value.as_ref())
+        EntryPath::conformant(value.as_ref())
     }
 }
 
-impl<'a> From<String> for EntryName<'a> {
+impl<'a> From<String> for EntryPath<'a> {
     #[inline]
     fn from(value: String) -> Self {
-        EntryName::conformant(value)
+        EntryPath::conformant(value)
     }
 }
 
-impl<'a> From<Cow<'a, str>> for EntryName<'a> {
+impl<'a> From<Cow<'a, str>> for EntryPath<'a> {
     #[inline]
     fn from(value: Cow<'a, str>) -> Self {
-        EntryName::conformant(value)
+        EntryPath::conformant(value)
     }
 }
 
-impl<'a> From<ZipFilePath<NormalizedPath<'a>>> for EntryName<'a> {
+impl<'a> From<ZipFilePath<NormalizedPath<'a>>> for EntryPath<'a> {
     #[inline]
     fn from(value: ZipFilePath<NormalizedPath<'a>>) -> Self {
-        EntryName(EntryNameInner::Normalized(value.data.0))
+        EntryPath(EntryPathInner::Normalized(value.data.0))
     }
 }
 
-impl<'a> From<ZipFilePath<NormalizedPathBuf>> for EntryName<'a> {
+impl<'a> From<ZipFilePath<NormalizedPathBuf>> for EntryPath<'a> {
     #[inline]
     fn from(value: ZipFilePath<NormalizedPathBuf>) -> Self {
-        EntryName(EntryNameInner::Normalized(Cow::Owned(value.data.0)))
+        EntryPath(EntryPathInner::Normalized(Cow::Owned(value.data.0)))
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,7 +6,7 @@ use crate::{
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
     mode::CREATOR_UNIX,
-    path::{EntryName, EntryNameInner, ZipFilePath, str_needs_utf8},
+    path::{EntryPath, EntryPathInner, ZipFilePath, str_needs_utf8},
     time::{DosDateTime, UtcDateTime},
 };
 use std::io::{self, Write};
@@ -25,32 +25,32 @@ const ZIP64_THRESHOLD_FILE_SIZE: u64 = u32::MAX as u64;
 const ZIP64_THRESHOLD_OFFSET: u64 = u32::MAX as u64;
 const ZIP64_THRESHOLD_ENTRIES: usize = u16::MAX as usize;
 
-fn with_resolved_entry_name<T>(
-    name: EntryName<'_>,
+fn with_resolved_entry_path<T>(
+    path: EntryPath<'_>,
     trim_trailing_slash: bool,
     write: impl FnOnce(&[u8], bool) -> T,
 ) -> T {
-    match name.0 {
-        EntryNameInner::Conformant(name) => {
+    match path.0 {
+        EntryPathInner::Conformant(path) => {
             // Normalize first, then strip a trailing slash.
-            let path = ZipFilePath::from_str(&name);
-            let name = if trim_trailing_slash {
+            let path = ZipFilePath::from_str(&path);
+            let path = if trim_trailing_slash {
                 path.trim_trailing_slash()
             } else {
                 path
             };
-            let name = name.as_str();
-            write(name.as_bytes(), str_needs_utf8(name))
+            let path = path.as_str();
+            write(path.as_bytes(), str_needs_utf8(path))
         }
-        EntryNameInner::Normalized(name) => {
-            let name = if trim_trailing_slash {
-                name.trim_end_matches('/')
+        EntryPathInner::Normalized(path) => {
+            let path = if trim_trailing_slash {
+                path.trim_end_matches('/')
             } else {
-                &name
+                &path
             };
-            write(name.as_bytes(), str_needs_utf8(name))
+            write(path.as_bytes(), str_needs_utf8(path))
         }
-        EntryNameInner::Verbatim(name) => write(&name, false),
+        EntryPathInner::Verbatim(path) => write(&path, false),
     }
 }
 
@@ -291,9 +291,9 @@ impl Crc32Option {
 
 /// A builder for creating a new file entry in a ZIP archive.
 #[derive(Debug)]
-pub struct ZipFileBuilder<'archive, 'name, W> {
+pub struct ZipFileBuilder<'archive, 'path, W> {
     archive: &'archive mut ZipArchiveWriter<W>,
-    name: EntryName<'name>,
+    path: EntryPath<'path>,
     compression_method: CompressionMethod,
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
@@ -538,7 +538,7 @@ where
             file_comment: self.file_comment,
             encrypted: self.encrypted,
         };
-        let entry_writer = self.archive.new_file_with_options(self.name, options)?;
+        let entry_writer = self.archive.new_file_with_options(self.path, options)?;
 
         let data_writer_config = ZipDataWriterConfig { crc32_option };
 
@@ -550,7 +550,7 @@ where
 #[derive(Debug)]
 pub struct ZipDirBuilder<'a, W> {
     archive: &'a mut ZipArchiveWriter<W>,
-    name: EntryName<'a>,
+    path: EntryPath<'a>,
     modification_time: Option<UtcDateTime>,
     unix_permissions: Option<u32>,
     extra_fields: ExtraFieldsContainer,
@@ -615,7 +615,7 @@ where
             file_comment: self.file_comment,
             encrypted: false,
         };
-        self.archive.new_dir_with_options(self.name, options)
+        self.archive.new_dir_with_options(self.path, options)
     }
 }
 
@@ -673,7 +673,7 @@ where
 
     /// Creates a builder for adding a new directory to the archive.
     ///
-    /// The name must end with `/`, including for [`EntryName::verbatim`].
+    /// The path must end with `/`, including for [`EntryPath::verbatim`].
     ///
     /// # Example
     ///
@@ -687,10 +687,10 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
-    pub fn new_dir<'a>(&'a mut self, name: impl Into<EntryName<'a>>) -> ZipDirBuilder<'a, W> {
+    pub fn new_dir<'a>(&'a mut self, path: impl Into<EntryPath<'a>>) -> ZipDirBuilder<'a, W> {
         ZipDirBuilder {
             archive: self,
-            name: name.into(),
+            path: path.into(),
             modification_time: None,
             unix_permissions: None,
             extra_fields: ExtraFieldsContainer::new(),
@@ -700,31 +700,31 @@ where
 
     /// Adds a new directory to the archive with options (internal method).
     ///
-    /// The name of the directory must end with a `/`.
+    /// The path of the directory must end with a `/`.
     fn new_dir_with_options(
         &mut self,
-        name: EntryName<'_>,
+        path: EntryPath<'_>,
         options: ZipEntryOptions,
     ) -> Result<(), Error> {
-        with_resolved_entry_name(name, false, |name, needs_utf8| {
-            self.write_dir_entry(name, needs_utf8, options)
+        with_resolved_entry_path(path, false, |path_bytes, needs_utf8| {
+            self.write_dir_entry(path_bytes, needs_utf8, options)
         })
     }
 
-    /// Writes a directory using resolved name bytes.
+    /// Writes a directory using resolved path bytes.
     fn write_dir_entry(
         &mut self,
-        name_bytes: &[u8],
+        path_bytes: &[u8],
         needs_utf8: bool,
         mut options: ZipEntryOptions,
     ) -> Result<(), Error> {
-        if !ZipFilePath::from_bytes(name_bytes).is_dir() {
+        if !ZipFilePath::from_bytes(path_bytes).is_dir() {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "not a directory".to_string(),
             }));
         }
 
-        if name_bytes.len() > u16::MAX as usize {
+        if path_bytes.len() > u16::MAX as usize {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "directory name too long".to_string(),
             }));
@@ -733,13 +733,13 @@ where
         let local_header_offset = self.writer.count();
         let flags = if needs_utf8 { FLAG_UTF8_ENCODING } else { 0 };
 
-        // Store the name bytes in the central buffer
-        let name_len = name_bytes.len() as u16;
-        self.file_names.extend_from_slice(name_bytes);
+        // Store the path bytes in the central buffer.
+        let name_len = path_bytes.len() as u16;
+        self.file_names.extend_from_slice(path_bytes);
 
         let file_comment_len = comment_len(&options.file_comment)?;
 
-        self.write_local_header(name_bytes, flags, CompressionMethod::Store, &mut options)?;
+        self.write_local_header(path_bytes, flags, CompressionMethod::Store, &mut options)?;
 
         self.file_comments.extend_from_slice(&options.file_comment);
 
@@ -763,7 +763,7 @@ where
 
     /// Creates a builder for adding a new file to the archive.
     ///
-    /// A trailing `/` is stripped unless the name is [`EntryName::verbatim`].
+    /// A trailing `/` is stripped unless the path is [`EntryPath::verbatim`].
     ///
     /// # Example
     ///
@@ -782,13 +782,13 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]
-    pub fn new_file<'name>(
+    pub fn new_file<'path>(
         &mut self,
-        name: impl Into<EntryName<'name>>,
-    ) -> ZipFileBuilder<'_, 'name, W> {
+        path: impl Into<EntryPath<'path>>,
+    ) -> ZipFileBuilder<'_, 'path, W> {
         ZipFileBuilder {
             archive: self,
-            name: name.into(),
+            path: path.into(),
             compression_method: CompressionMethod::Store,
             modification_time: None,
             unix_permissions: None,
@@ -802,22 +802,22 @@ where
     /// Adds a new file to the archive with options (internal method).
     fn new_file_with_options(
         &mut self,
-        name: EntryName<'_>,
+        path: EntryPath<'_>,
         options: ZipEntryOptions,
     ) -> Result<ZipEntryWriter<'_, W>, Error> {
-        with_resolved_entry_name(name, true, |name, needs_utf8| {
-            self.write_file_entry(name, needs_utf8, options)
+        with_resolved_entry_path(path, true, |path_bytes, needs_utf8| {
+            self.write_file_entry(path_bytes, needs_utf8, options)
         })
     }
 
-    /// Writes a file using resolved name bytes.
+    /// Writes a file using resolved path bytes.
     fn write_file_entry(
         &mut self,
-        name_bytes: &[u8],
+        path_bytes: &[u8],
         needs_utf8: bool,
         mut options: ZipEntryOptions,
     ) -> Result<ZipEntryWriter<'_, W>, Error> {
-        if name_bytes.len() > u16::MAX as usize {
+        if path_bytes.len() > u16::MAX as usize {
             return Err(Error::from(ErrorKind::InvalidInput {
                 msg: "file name too long".to_string(),
             }));
@@ -832,13 +832,13 @@ where
             flags |= FLAG_ENCRYPTED;
         }
 
-        // Store the name bytes in the central buffer
-        let name_len = name_bytes.len() as u16;
-        self.file_names.extend_from_slice(name_bytes);
+        // Store the path bytes in the central buffer.
+        let name_len = path_bytes.len() as u16;
+        self.file_names.extend_from_slice(path_bytes);
 
         let file_comment_len = comment_len(&options.file_comment)?;
 
-        self.write_local_header(name_bytes, flags, options.compression_method, &mut options)?;
+        self.write_local_header(path_bytes, flags, options.compression_method, &mut options)?;
 
         self.file_comments.extend_from_slice(&options.file_comment);
 

--- a/tests/it/entry_path_tests.rs
+++ b/tests/it/entry_path_tests.rs
@@ -1,11 +1,11 @@
-use rawzip::{EntryName, ZipArchive, ZipArchiveWriter};
+use rawzip::{EntryPath, ZipArchive, ZipArchiveWriter};
 use std::io::Write;
 
 /// Writes one file and returns the archive.
-fn write_one<'n>(name: impl Into<EntryName<'n>>) -> Vec<u8> {
+fn write_one<'p>(path: impl Into<EntryPath<'p>>) -> Vec<u8> {
     let mut output = Vec::new();
     let mut archive = ZipArchiveWriter::new(&mut output);
-    let (mut entry, config) = archive.new_file(name).start().unwrap();
+    let (mut entry, config) = archive.new_file(path).start().unwrap();
     let mut writer = config.wrap(&mut entry);
     writer.write_all(b"content").unwrap();
     let (_, descriptor) = writer.finish().unwrap();
@@ -15,18 +15,18 @@ fn write_one<'n>(name: impl Into<EntryName<'n>>) -> Vec<u8> {
 }
 
 #[test]
-fn borrowed_str_reference_is_an_entry_name() {
-    let name = "file.txt";
-    let name_ref: &&str = &name;
-    let output = write_one(name_ref);
+fn borrowed_str_reference_is_an_entry_path() {
+    let path = "file.txt";
+    let path_ref: &&str = &path;
+    let output = write_one(path_ref);
     let archive = ZipArchive::from_slice(&output).unwrap();
     let entry = archive.entries().next().unwrap().unwrap();
 
     assert_eq!(entry.file_path().as_ref(), b"file.txt");
 }
 
-/// Reads the first entry's raw name.
-fn first_entry_name(zip_data: &[u8]) -> Vec<u8> {
+/// Reads the first entry's raw path.
+fn first_entry_path(zip_data: &[u8]) -> Vec<u8> {
     let archive = ZipArchive::from_slice(zip_data).unwrap();
     let mut entries = archive.entries();
     let entry = entries.next_entry().unwrap().unwrap();
@@ -47,10 +47,10 @@ fn verbatim_shift_jis_roundtrip() {
     raw.extend_from_slice(b".txt");
     assert!(std::str::from_utf8(&raw).is_err());
 
-    let output = write_one(EntryName::verbatim(raw.as_slice()));
+    let output = write_one(EntryPath::verbatim(raw.as_slice()));
 
     assert_eq!(
-        first_entry_name(&output),
+        first_entry_path(&output),
         raw,
         "bytes must be preserved exactly"
     );
@@ -61,32 +61,32 @@ fn verbatim_shift_jis_roundtrip() {
 #[test]
 fn verbatim_valid_utf8_no_flag() {
     let raw = "日本.txt".as_bytes();
-    let output = write_one(EntryName::verbatim(raw));
+    let output = write_one(EntryPath::verbatim(raw));
 
-    assert_eq!(first_entry_name(&output), raw);
+    assert_eq!(first_entry_path(&output), raw);
     assert!(!first_entry_is_utf8(&output));
 }
 
-/// Conformant non-ASCII names set the UTF-8 flag.
+/// Conformant non-ASCII paths set the UTF-8 flag.
 #[test]
 fn conformant_non_ascii_sets_flag() {
-    let output = write_one(EntryName::conformant("日本.txt"));
-    assert_eq!(first_entry_name(&output), "日本.txt".as_bytes());
+    let output = write_one(EntryPath::conformant("日本.txt"));
+    assert_eq!(first_entry_path(&output), "日本.txt".as_bytes());
     assert!(first_entry_is_utf8(&output));
 }
 
-/// String names retain traversal normalization.
+/// String paths retain traversal normalization.
 #[test]
 fn conformant_traversal_collapses_to_root() {
     let output = write_one("../../etc/passwd");
-    assert_eq!(first_entry_name(&output), b"etc/passwd");
+    assert_eq!(first_entry_path(&output), b"etc/passwd");
 }
 
-/// Reader-normalized names can be written directly.
+/// Reader-normalized paths can be written directly.
 #[test]
 fn normalized_skip_arm_roundtrip() {
     // Build an entry requiring normalization.
-    let source = write_one(EntryName::verbatim(b"dir/../safe.txt".as_slice()));
+    let source = write_one(EntryPath::verbatim(b"dir/../safe.txt".as_slice()));
     let src_archive = ZipArchive::from_slice(&source).unwrap();
     let mut entries = src_archive.entries();
     let entry = entries.next_entry().unwrap().unwrap();
@@ -95,12 +95,12 @@ fn normalized_skip_arm_roundtrip() {
 
     // Write the normalized path directly.
     let output = write_one(safe);
-    assert_eq!(first_entry_name(&output), b"safe.txt");
+    assert_eq!(first_entry_path(&output), b"safe.txt");
 }
 
-/// Files and directories accept owned names.
+/// Files and directories accept owned paths.
 #[test]
-fn owned_names_accepted() {
+fn owned_paths_accepted() {
     let mut output = Vec::new();
     let mut archive = ZipArchiveWriter::new(&mut output);
     archive.new_dir(String::from("d/")).create().unwrap();

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 mod crc_tests;
 mod encryption_tests;
-mod entry_name_tests;
+mod entry_path_tests;
 mod extra_data_zip_tests;
 mod extra_fields_test;
 mod false_sentinel_tests;


### PR DESCRIPTION
If the read side of this API is called ZipFilePath, it is more symmetrical to rename EntryName to EntryPath (it's in the path module after all ;)). We want ZipFilePath and EntryPath to be separate types as EntryPath will encode intent in case there is a future need for further customizing normalization