### PR TITLE
Expose incremental crc accumulator

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,4 +1,3 @@
-use crate::crc::crc32_chunk;
 use crate::errors::{Error, ErrorKind};
 use crate::extra_fields::{ExtraFieldId, ExtraFields};
 use crate::headers::EntryFlags;
@@ -10,7 +9,7 @@ use crate::path::{RawPath, ZipFilePath};
 use crate::reader_at::{FileReader, MutexReader, RangeReader, ReaderAt, ReaderAtExt};
 use crate::time::{DosDateTime, ZipDateTimeKind, extract_best_timestamp};
 use crate::utils::{le_u16, le_u32, le_u64};
-use crate::{EndOfCentralDirectory, EndOfCentralDirectoryRecordFixed, ZipLocator};
+use crate::{Crc32, EndOfCentralDirectory, EndOfCentralDirectoryRecordFixed, ZipLocator};
 use std::io::{Read, Seek, Write};
 
 pub(crate) const END_OF_CENTRAL_DIR_SIGNATURE64: u32 = 0x06064b50;
@@ -239,7 +238,7 @@ impl<'a> ZipSliceEntry<'a> {
         ZipSliceVerifier(ZipVerifier {
             reader,
             verifier: self.verifier,
-            crc: 0,
+            crc: Crc32::new(),
             size: 0,
         })
     }
@@ -691,7 +690,7 @@ where
     {
         ZipVerifier {
             reader,
-            crc: 0,
+            crc: Crc32::new(),
             size: 0,
             verifier: ZipVerification {
                 crc: self.entry.crc,
@@ -874,7 +873,7 @@ impl ZipVerification {
 #[derive(Debug, Clone)]
 pub struct ZipVerifier<Decompressor> {
     reader: Decompressor,
-    crc: u32,
+    crc: Crc32,
     size: u64,
     verifier: ZipVerification,
 }
@@ -897,13 +896,13 @@ where
         }
 
         let read = self.reader.read(buf)?;
-        self.crc = crc32_chunk(&buf[..read], self.crc);
+        self.crc.update(&buf[..read]);
         self.size += read as u64;
 
         if read == 0 || self.size >= self.verifier.uncompressed_size {
             self.verifier
                 .valid(ZipVerification {
-                    crc: self.crc,
+                    crc: self.crc.checksum(),
                     uncompressed_size: self.size,
                 })
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -45,8 +45,9 @@ pub(crate) fn crc32_byte(crc: u32, byte: u8) -> u32 {
 /// Compute the CRC32 (IEEE) of a byte slice
 ///
 /// Typically this function is used only to compute the CRC32 of data that is
-/// held entirely in memory. When decompressing, a
-/// [`ZipVerifier`](crate::ZipVerifier) is suitable to streaming computations.
+/// held entirely in memory. When the bytes arrive incrementally, fold them with
+/// [`Crc32`] instead, or let a [`ZipVerifier`](crate::ZipVerifier) handle the
+/// streaming computation while decompressing.
 ///
 /// While this crc implementation is the fastest known on Wasm, it falls a bit
 /// short on native platforms. In a benchmark, using hardware intrinsics like
@@ -60,7 +61,47 @@ pub(crate) fn crc32_byte(crc: u32, byte: u8) -> u32 {
 /// always bring your own CRC implementation with
 /// [`crate::ZipReader::claim_verifier`].
 pub fn crc32(data: &[u8]) -> u32 {
-    crc32_chunk(data, 0)
+    !crc32_fold(data, !0)
+}
+
+/// Streaming CRC32 accumulator.
+///
+/// ```rust
+/// # use rawzip::Crc32;
+/// let mut crc = Crc32::new();
+/// crc.update(b"Hello, ");
+/// crc.update(b"world!");
+/// assert_eq!(crc.checksum(), rawzip::crc32(b"Hello, world!"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct Crc32 {
+    state: u32,
+}
+
+impl Crc32 {
+    /// Creates a new accumulator with no data
+    #[inline]
+    pub fn new() -> Self {
+        Crc32 { state: !0 }
+    }
+
+    /// Folds more bytes into the running checksum.
+    #[inline]
+    pub fn update(&mut self, data: &[u8]) {
+        self.state = crc32_fold(data, self.state);
+    }
+
+    /// Returns the CRC32 of the data folded in so far.
+    #[inline]
+    pub fn checksum(&self) -> u32 {
+        !self.state
+    }
+}
+
+impl Default for Crc32 {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[inline(always)]
@@ -85,9 +126,9 @@ fn crc32_slice16(data: &[u8], crc: u32) -> u32 {
 }
 
 #[inline]
-pub fn crc32_chunk(data: &[u8], prev: u32) -> u32 {
+fn crc32_fold(data: &[u8], state: u32) -> u32 {
     let mut chunks32 = data.chunks_exact(32);
-    let mut crc = chunks32.by_ref().fold(!prev, |crc, data| {
+    let mut crc = chunks32.by_ref().fold(state, |crc, data| {
         let crc = crc32_slice16(data, crc);
         crc32_slice16(&data[16..], crc)
     });
@@ -97,7 +138,7 @@ pub fn crc32_chunk(data: &[u8], prev: u32) -> u32 {
         .iter()
         .fold(crc, |crc, &x| crc32_byte(crc, x));
 
-    !crc
+    crc
 }
 
 #[cfg(test)]
@@ -141,11 +182,12 @@ mod tests {
     }
 
     #[test]
-    fn test_crc_chunk_streaming() {
+    fn test_crc32_accumulator_streaming() {
         let data: Vec<u8> = (0u8..=255).cycle().take(4096).collect();
         let full = crc32(&data);
-        let half = crc32_chunk(&data[..2048], 0);
-        let streamed = crc32_chunk(&data[2048..], half);
-        assert_eq!(full, streamed);
+        let mut streamed = Crc32::new();
+        streamed.update(&data[..2048]);
+        streamed.update(&data[2048..]);
+        assert_eq!(full, streamed.checksum());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod writer;
 pub mod zipcrypto;
 
 pub use archive::*;
-pub use crc::crc32;
+pub use crc::{Crc32, crc32};
 pub use errors::{Error, ErrorKind};
 pub use headers::{EntryFlags, Header};
 pub use locator::*;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,8 +1,8 @@
 use crate::{
-    CENTRAL_HEADER_SIGNATURE, CompressionMethod, DataDescriptor,
+    CENTRAL_HEADER_SIGNATURE, CompressionMethod, Crc32, DataDescriptor,
     END_OF_CENTRAL_DIR_LOCATOR_SIGNATURE, END_OF_CENTRAL_DIR_SIGNATURE64,
     END_OF_CENTRAL_DIR_SIGNAUTRE_BYTES, EntryFlags, Error, Header, ZipFileHeaderFixed,
-    ZipLocalFileHeaderFixed, crc,
+    ZipLocalFileHeaderFixed,
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
     mode::CREATOR_UNIX,
@@ -1112,8 +1112,36 @@ where
 pub struct ZipDataWriter<W> {
     inner: W,
     uncompressed_bytes: u64,
-    crc: u32,
-    crc32_option: Crc32Option,
+    crc: ZipDataWriterCrc32,
+}
+
+#[derive(Debug, Clone)]
+enum ZipDataWriterCrc32 {
+    Calculate(Crc32),
+    Fixed(u32),
+}
+
+impl ZipDataWriterCrc32 {
+    fn new(option: Crc32Option) -> Self {
+        match option {
+            Crc32Option::Calculate => ZipDataWriterCrc32::Calculate(Crc32::new()),
+            Crc32Option::Custom(value) => ZipDataWriterCrc32::Fixed(value),
+            Crc32Option::Skip => ZipDataWriterCrc32::Fixed(0),
+        }
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        if let ZipDataWriterCrc32::Calculate(crc) = self {
+            crc.update(data);
+        }
+    }
+
+    fn checksum(&self) -> u32 {
+        match self {
+            ZipDataWriterCrc32::Calculate(crc) => crc.checksum(),
+            ZipDataWriterCrc32::Fixed(value) => *value,
+        }
+    }
 }
 
 impl<W> ZipDataWriter<W> {
@@ -1127,12 +1155,10 @@ impl<W> ZipDataWriter<W> {
 
     /// Creates a new `ZipDataWriter` with a specific CRC32 calculation option.
     fn with_crc32_option(inner: W, crc32_option: Crc32Option) -> Self {
-        let crc = crc32_option.initial_value();
         ZipDataWriter {
             inner,
             uncompressed_bytes: 0,
-            crc,
-            crc32_option,
+            crc: ZipDataWriterCrc32::new(crc32_option),
         }
     }
 
@@ -1156,7 +1182,7 @@ impl<W> ZipDataWriter<W> {
     {
         self.flush()?;
         let output = DataDescriptorOutput {
-            crc: self.crc,
+            crc: self.crc.checksum(),
             compressed_size: 0,
             uncompressed_size: self.uncompressed_bytes,
         };
@@ -1172,11 +1198,7 @@ where
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let bytes_written = self.inner.write(buf)?;
         self.uncompressed_bytes += bytes_written as u64;
-
-        // Only calculate CRC32 if the option is Calculate
-        if matches!(self.crc32_option, Crc32Option::Calculate) {
-            self.crc = crc::crc32_chunk(&buf[..bytes_written], self.crc);
-        }
+        self.crc.update(&buf[..bytes_written]);
 
         Ok(bytes_written)
     }

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -159,36 +159,63 @@ fn full_read_verifies_without_finish() {
     assert_invalid_checksum(err, corrupted, original);
 }
 
-struct CustomCrcVerifier<R> {
-    reader: flate2::CrcReader<DeflateDecoder<ZipReader<R>>>,
+trait Checksum {
+    fn update(&mut self, data: &[u8]);
+    fn checksum(&self) -> u32;
+}
+
+impl Checksum for rawzip::Crc32 {
+    fn update(&mut self, data: &[u8]) {
+        rawzip::Crc32::update(self, data);
+    }
+    fn checksum(&self) -> u32 {
+        rawzip::Crc32::checksum(self)
+    }
+}
+
+impl Checksum for flate2::Crc {
+    fn update(&mut self, data: &[u8]) {
+        flate2::Crc::update(self, data);
+    }
+    fn checksum(&self) -> u32 {
+        self.sum()
+    }
+}
+
+/// A streaming verifying reader generic over the crc backend.
+struct CustomCrcVerifier<R, C> {
+    reader: DeflateDecoder<ZipReader<R>>,
+    crc: C,
     size: u64,
     verifications: usize,
 }
 
-impl<R: ReaderAt> CustomCrcVerifier<R> {
-    fn new(reader: ZipReader<R>) -> Self {
+impl<R: ReaderAt, C: Checksum> CustomCrcVerifier<R, C> {
+    fn new(reader: ZipReader<R>, crc: C) -> Self {
         Self {
-            reader: flate2::CrcReader::new(DeflateDecoder::new(reader)),
+            reader: DeflateDecoder::new(reader),
+            crc,
             size: 0,
             verifications: 0,
         }
     }
 }
 
-impl<R: ReaderAt> Read for CustomCrcVerifier<R> {
+impl<R: ReaderAt, C: Checksum> Read for CustomCrcVerifier<R, C> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
         }
 
         let read = self.reader.read(buf)?;
+        self.crc.update(&buf[..read]);
         self.size += read as u64;
 
-        let expected = self.reader.get_ref().get_ref().claim_verifier();
+        let expected = self.reader.get_ref().claim_verifier();
         if read == 0 || self.size >= expected.uncompressed_size {
             expected
                 .valid(ZipVerification {
-                    crc: self.reader.crc().sum(),
+                    crc: self.crc.checksum(),
                     uncompressed_size: self.size,
                 })
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -199,13 +226,12 @@ impl<R: ReaderAt> Read for CustomCrcVerifier<R> {
     }
 }
 
-#[test]
-fn custom_crc_verifier_empty_buffer_and_eof_verification() {
+fn run_custom_crc_verifier_eof<C: Checksum>(crc: C) {
     let data = build_deflate_zip(CONTENT);
     let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
-    let mut verifier = CustomCrcVerifier::new(ent.reader());
+    let mut verifier = CustomCrcVerifier::new(ent.reader(), crc);
 
     // An empty target buffer must not be treated as EOF.
     assert_eq!(verifier.read(&mut []).unwrap(), 0);
@@ -219,6 +245,12 @@ fn custom_crc_verifier_empty_buffer_and_eof_verification() {
     // Redundant reads past EOF stay at EOF and run the same verification path.
     assert_eq!(verifier.read(&mut [0u8; 16]).unwrap(), 0);
     assert_eq!(verifier.verifications, 3);
+}
+
+#[test]
+fn custom_crc_verifier_empty_buffer_and_eof_verification() {
+    run_custom_crc_verifier_eof(flate2::Crc::new());
+    run_custom_crc_verifier_eof(rawzip::Crc32::new());
 }
 
 #[test]


### PR DESCRIPTION
This allows one to create their own `ZipVerifier` equivalent with their custom verification policy but still leverage rawzip's crc implementation.