### PR TITLE
Export ZipCreatorSystem, raw mode and raw external file attrs and version_made_by.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ The reason is to prevent breaking changes in the future by properly modeling unk
 
 - Expose the slice reading APIs under "no std" and "no alloc" cargo feature flags
 - Add `EntryFlags` to expose the general purpose bit flags on file entries
+- Add `ZipFileHeaderRecord::version_made_by` returning a `VersionMadeBy` with a `CreatorSystem` and zip version
+- Add `ZipFileHeaderRecord::external_attributes` to expose the raw external file attributes
 - Add `ZipFileHeaderRecord::comment` for zip entry central directory comment
 - Allow writing file names encoded as byte verbatim without requiring UTF-8 through `EntryPath` argument
 - Add ability to write archive and central directory comments

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -3,7 +3,9 @@ use crate::Crc32;
 use crate::errors::{Error, ErrorKind};
 use crate::extra_fields::{ExtraFieldId, ExtraFields};
 use crate::headers::EntryFlags;
-use crate::mode::{EntryMode, ZipCreatorSystem, msdos_mode_to_file_mode, unix_mode_to_file_mode};
+use crate::mode::{
+    CreatorSystem, EntryMode, VersionMadeBy, msdos_mode_to_file_mode, unix_mode_to_file_mode,
+};
 use crate::path::{RawPath, ZipFilePath};
 #[cfg(feature = "std")]
 use crate::reader_at::{ReaderAt, ReaderAtExt};
@@ -713,27 +715,6 @@ impl DataDescriptor {
     }
 }
 
-/// 4.4.2
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct VersionMadeBy(u16);
-
-#[allow(dead_code)]
-impl VersionMadeBy {
-    pub fn as_u16(&self) -> u16 {
-        self.0
-    }
-
-    /// The (major, minor) ZIP specification version supported by the software
-    /// used to encode the file.
-    ///
-    /// 4.4.2.3: The lower byte, The value / 10 indicates the major version
-    /// number, and the value mod 10 is the minor version number.
-    pub fn version(&self) -> (u8, u8) {
-        let v = (self.0 >> 8) as u8;
-        (v / 10, v % 10)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct Zip64EndOfCentralDirectory {
     pub offset: u64,
@@ -807,7 +788,7 @@ impl Zip64EndOfCentralDirectoryRecord {
         let result = Zip64EndOfCentralDirectoryRecord {
             signature: le_u32(&data[0..4]),
             size: le_u64(&data[4..12]),
-            version_made_by: VersionMadeBy(le_u16(&data[12..14])),
+            version_made_by: VersionMadeBy::from_raw(le_u16(&data[12..14])),
             version_needed: le_u16(&data[14..16]),
             disk_number: le_u32(&data[16..20]),
             cd_disk: le_u32(&data[20..24]),
@@ -1313,19 +1294,19 @@ println!("Safe path: {}", safe_path.as_ref());
     }
 
     /// Returns the file mode information extracted from the external file attributes.
+    ///
+    /// Is a convenience method over interpreting
+    /// [`version_made_by`](Self::version_made_by) and
+    /// [`external_attributes`](Self::external_attributes).
     #[inline]
     pub fn mode(&self) -> EntryMode {
-        let creator_version = self.version_made_by >> 8;
-
-        let mut mode = match creator_version {
-            // Unix and macOS
-            ZipCreatorSystem::CREATOR_UNIX | ZipCreatorSystem::CREATOR_MACOS => {
+        let mut mode = match self.version_made_by().creator_system() {
+            CreatorSystem::UNIX | CreatorSystem::MACOS => {
                 unix_mode_to_file_mode(self.external_file_attrs >> 16)
             }
-            // NTFS, VFAT, FAT
-            ZipCreatorSystem::CREATOR_NTFS
-            | ZipCreatorSystem::CREATOR_VFAT
-            | ZipCreatorSystem::CREATOR_FAT => msdos_mode_to_file_mode(self.external_file_attrs),
+            CreatorSystem::FAT | CreatorSystem::NTFS | CreatorSystem::MVS | CreatorSystem::VFAT => {
+                msdos_mode_to_file_mode(self.external_file_attrs)
+            }
             // default to basic permissions
             _ => 0o644,
         };
@@ -1338,24 +1319,19 @@ println!("Safe path: {}", safe_path.as_ref());
         EntryMode::new(mode)
     }
 
-    /// Return raw value for external file attrs.
-    ///
-    /// For general use use [`Self::mode`] function.
-    ///
-    /// Interpretation of this value is heavily dependent on correct interpretation of
-    ///   [`Self::version_made_by_raw`] value.
-    pub fn external_file_attrs_raw(&self) -> u32 {
-        self.external_file_attrs
+    /// Returns the "version made by" field stored in the central directory record.
+    #[inline]
+    pub fn version_made_by(&self) -> VersionMadeBy {
+        VersionMadeBy::from_raw(self.version_made_by)
     }
 
-    /// Return raw value for version_made_by header field.
+    /// Returns the raw external file attributes stored in the central directory.
     ///
-    /// For general use use [`Self::mode`] function.
-    ///
-    /// Interpretation [`Self::external_file_attrs_raw`] value is heavily dependent
-    ///   on correct interpretation of this field.
-    pub fn version_made_by_raw(&self) -> u16 {
-        self.version_made_by
+    /// Consider if [`mode`](Self::mode) is a better alternative than accessing
+    /// the raw bytes.
+    #[inline]
+    pub fn external_attributes(&self) -> u32 {
+        self.external_file_attrs
     }
 
     /// The declared CRC32 checksum of the uncompressed data.

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -3,10 +3,7 @@ use crate::Crc32;
 use crate::errors::{Error, ErrorKind};
 use crate::extra_fields::{ExtraFieldId, ExtraFields};
 use crate::headers::EntryFlags;
-use crate::mode::{
-    CREATOR_FAT, CREATOR_MACOS, CREATOR_NTFS, CREATOR_UNIX, CREATOR_VFAT, EntryMode,
-    msdos_mode_to_file_mode, unix_mode_to_file_mode,
-};
+use crate::mode::{EntryMode, ZipCreatorSystem, msdos_mode_to_file_mode, unix_mode_to_file_mode};
 use crate::path::{RawPath, ZipFilePath};
 #[cfg(feature = "std")]
 use crate::reader_at::{ReaderAt, ReaderAtExt};
@@ -1322,11 +1319,13 @@ println!("Safe path: {}", safe_path.as_ref());
 
         let mut mode = match creator_version {
             // Unix and macOS
-            CREATOR_UNIX | CREATOR_MACOS => unix_mode_to_file_mode(self.external_file_attrs >> 16),
-            // NTFS, VFAT, FAT
-            CREATOR_NTFS | CREATOR_VFAT | CREATOR_FAT => {
-                msdos_mode_to_file_mode(self.external_file_attrs)
+            ZipCreatorSystem::CREATOR_UNIX | ZipCreatorSystem::CREATOR_MACOS => {
+                unix_mode_to_file_mode(self.external_file_attrs >> 16)
             }
+            // NTFS, VFAT, FAT
+            ZipCreatorSystem::CREATOR_NTFS
+            | ZipCreatorSystem::CREATOR_VFAT
+            | ZipCreatorSystem::CREATOR_FAT => msdos_mode_to_file_mode(self.external_file_attrs),
             // default to basic permissions
             _ => 0o644,
         };
@@ -1337,6 +1336,26 @@ println!("Safe path: {}", safe_path.as_ref());
         }
 
         EntryMode::new(mode)
+    }
+
+    /// Return raw value for external file attrs.
+    ///
+    /// For general use use [`Self::mode`] function.
+    ///
+    /// Interpretation of this value is heavily dependent on correct interpretation of
+    ///   [`Self::version_made_by_raw`] value.
+    pub fn external_file_attrs_raw(&self) -> u32 {
+        self.external_file_attrs
+    }
+
+    /// Return raw value for version_made_by header field.
+    ///
+    /// For general use use [`Self::mode`] function.
+    ///
+    /// Interpretation [`Self::external_file_attrs_raw`] value is heavily dependent
+    ///   on correct interpretation of this field.
+    pub fn version_made_by_raw(&self) -> u16 {
+        self.version_made_by
     }
 
     /// The declared CRC32 checksum of the uncompressed data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use headers::EntryFlags;
 #[cfg(feature = "std")]
 pub use headers::Header;
 pub use locator::*;
-pub use mode::EntryMode;
+pub use mode::{CreatorSystem, EntryMode, VersionMadeBy};
 #[cfg(feature = "alloc")]
 pub use path::EntryPath;
 #[cfg(feature = "std")]

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,9 +1,13 @@
 /// ZIP creator system constants used in version_made_by field
-pub(crate) const CREATOR_UNIX: u16 = 3;
-pub(crate) const CREATOR_MACOS: u16 = 19;
-pub(crate) const CREATOR_NTFS: u16 = 11;
-pub(crate) const CREATOR_VFAT: u16 = 14;
-pub(crate) const CREATOR_FAT: u16 = 0;
+pub enum ZipCreatorSystem {}
+
+impl ZipCreatorSystem {
+    pub const CREATOR_UNIX: u16 = 3;
+    pub const CREATOR_MACOS: u16 = 19;
+    pub const CREATOR_NTFS: u16 = 11;
+    pub const CREATOR_VFAT: u16 = 14;
+    pub const CREATOR_FAT: u16 = 0;
+}
 
 /// File mode information for a given zip file entry.
 ///

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,12 +1,108 @@
-/// ZIP creator system constants used in version_made_by field
-pub enum ZipCreatorSystem {}
+/// The host system that produced a zip entry.
+///
+/// Derived from central directory "version made by" (APPNOTE § 4.4.2.2)
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CreatorSystem(u8);
 
-impl ZipCreatorSystem {
-    pub const CREATOR_UNIX: u16 = 3;
-    pub const CREATOR_MACOS: u16 = 19;
-    pub const CREATOR_NTFS: u16 = 11;
-    pub const CREATOR_VFAT: u16 = 14;
-    pub const CREATOR_FAT: u16 = 0;
+impl CreatorSystem {
+    pub const FAT: Self = Self(0);
+    pub const UNIX: Self = Self(3);
+    pub const NTFS: Self = Self(10);
+
+    /// Go and Info-ZIP calls this NTFS
+    pub const MVS: Self = Self(11);
+    pub const VFAT: Self = Self(14);
+    pub const MACOS: Self = Self(19);
+
+    /// Wraps a raw creator-system identifier.
+    #[inline]
+    pub const fn new(id: u8) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw creator-system identifier.
+    #[inline]
+    pub const fn as_u8(self) -> u8 {
+        self.0
+    }
+
+    /// Returns the creator-system name (e.g. `"UNIX"`) when known.
+    #[inline]
+    pub const fn name(self) -> Option<&'static str> {
+        match self.0 {
+            0 => Some("FAT"),
+            3 => Some("UNIX"),
+            10 => Some("NTFS"),
+            11 => Some("MVS"),
+            14 => Some("VFAT"),
+            19 => Some("MACOS"),
+            _ => None,
+        }
+    }
+}
+
+impl core::fmt::Debug for CreatorSystem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.name() {
+            Some(name) => write!(f, "CreatorSystem::{name}"),
+            None => write!(f, "CreatorSystem({})", self.0),
+        }
+    }
+}
+
+impl core::fmt::Display for CreatorSystem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} ({})", self.0, self.name().unwrap_or("UNKNOWN"))
+    }
+}
+
+impl From<u8> for CreatorSystem {
+    fn from(id: u8) -> Self {
+        Self(id)
+    }
+}
+
+/// The "version made by" field from a central directory record
+///
+/// (APPNOTE § 4.4.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VersionMadeBy(u16);
+
+impl VersionMadeBy {
+    /// Builds a value from a creator system and a ZIP specification version (in
+    /// tenths, e.g. `20` for version 2.0).
+    #[inline]
+    pub(crate) const fn new(system: CreatorSystem, zip_version: u8) -> Self {
+        Self(((system.as_u8() as u16) << 8) | zip_version as u16)
+    }
+
+    /// Wraps a raw "version made by" value.
+    #[inline]
+    pub const fn from_raw(value: u16) -> Self {
+        Self(value)
+    }
+
+    /// The host system that created the entry (the high byte).
+    #[inline]
+    pub const fn creator_system(self) -> CreatorSystem {
+        CreatorSystem((self.0 >> 8) as u8)
+    }
+
+    /// The ZIP specification version supported by the software that created the
+    /// entry.
+    ///
+    /// The value is encoded in tenths (APPNOTE § 4.4.2.3). For example, `20`
+    /// means version 2.0 and `45` means 4.5.
+    #[inline]
+    pub const fn zip_version(self) -> u8 {
+        self.0 as u8
+    }
+
+    /// Returns the raw "version made by" value.
+    #[inline]
+    pub const fn as_u16(self) -> u16 {
+        self.0
+    }
 }
 
 /// File mode information for a given zip file entry.
@@ -95,5 +191,58 @@ pub(crate) fn msdos_mode_to_file_mode(m: u32) -> u32 {
         S_IFREG | 0o444
     } else {
         S_IFREG | 0o666
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate alloc;
+    use alloc::format;
+
+    #[test]
+    fn creator_system_known_names() {
+        assert_eq!(CreatorSystem::FAT.name(), Some("FAT"));
+        assert_eq!(CreatorSystem::UNIX.name(), Some("UNIX"));
+        assert_eq!(CreatorSystem::NTFS.name(), Some("NTFS"));
+        assert_eq!(CreatorSystem::MVS.name(), Some("MVS"));
+        assert_eq!(CreatorSystem::VFAT.name(), Some("VFAT"));
+        assert_eq!(CreatorSystem::MACOS.name(), Some("MACOS"));
+        assert_eq!(CreatorSystem::new(7).name(), None);
+        assert_eq!(CreatorSystem::NTFS.as_u8(), 10);
+        assert_eq!(CreatorSystem::MVS.as_u8(), 11);
+    }
+
+    #[test]
+    fn creator_system_raw_roundtrip() {
+        for id in [0u8, 3, 10, 11, 14, 19, 7, 255] {
+            assert_eq!(CreatorSystem::new(id).as_u8(), id);
+            assert_eq!(CreatorSystem::from(id), CreatorSystem::new(id));
+        }
+    }
+
+    #[test]
+    fn creator_system_debug_and_display() {
+        assert_eq!(format!("{:?}", CreatorSystem::UNIX), "CreatorSystem::UNIX");
+        assert_eq!(format!("{:?}", CreatorSystem::new(7)), "CreatorSystem(7)");
+        assert_eq!(format!("{}", CreatorSystem::UNIX), "3 (UNIX)");
+        assert_eq!(format!("{}", CreatorSystem::new(7)), "7 (UNKNOWN)");
+    }
+
+    #[test]
+    fn version_made_by_decomposition() {
+        // High byte = creator system, low byte = zip version (tenths).
+        let v = VersionMadeBy::from_raw(0x031e);
+        assert_eq!(v.creator_system(), CreatorSystem::UNIX);
+        assert_eq!(v.zip_version(), 30);
+        assert_eq!(v.as_u16(), 0x031e);
+    }
+
+    #[test]
+    fn version_made_by_new_matches_raw() {
+        let v = VersionMadeBy::new(CreatorSystem::MACOS, 20);
+        assert_eq!(v.as_u16(), (19 << 8) | 20);
+        assert_eq!(v.creator_system(), CreatorSystem::MACOS);
+        assert_eq!(v.zip_version(), 20);
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,7 +5,7 @@ use crate::{
     ZipLocalFileHeaderFixed,
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
-    mode::ZipCreatorSystem,
+    mode::{CreatorSystem, VersionMadeBy},
     path::{EntryPath, EntryPathInner, ZipFilePath, str_needs_utf8},
     time::{DosDateTime, UtcDateTime},
 };
@@ -876,11 +876,11 @@ where
             };
 
             // Set version_made_by to indicate Unix when Unix permissions are present
-            let version_made_by_hi = file
+            let creator_system = file
                 .unix_permissions
-                .map(|_| ZipCreatorSystem::CREATOR_UNIX)
-                .unwrap_or(0);
-            let version_made_by = (version_made_by_hi << 8) | version_needed;
+                .map(|_| CreatorSystem::UNIX)
+                .unwrap_or(CreatorSystem::FAT);
+            let version_made_by = VersionMadeBy::new(creator_system, version_needed as u8).as_u16();
 
             let dos = file
                 .modification_time

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,7 +5,7 @@ use crate::{
     ZipLocalFileHeaderFixed,
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
-    mode::CREATOR_UNIX,
+    mode::ZipCreatorSystem,
     path::{EntryPath, EntryPathInner, ZipFilePath, str_needs_utf8},
     time::{DosDateTime, UtcDateTime},
 };
@@ -876,7 +876,10 @@ where
             };
 
             // Set version_made_by to indicate Unix when Unix permissions are present
-            let version_made_by_hi = file.unix_permissions.map(|_| CREATOR_UNIX).unwrap_or(0);
+            let version_made_by_hi = file
+                .unix_permissions
+                .map(|_| ZipCreatorSystem::CREATOR_UNIX)
+                .unwrap_or(0);
             let version_made_by = (version_made_by_hi << 8) | version_needed;
 
             let dos = file

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,7 +3,7 @@
 use quickcheck_macros::quickcheck;
 use rawzip::extra_fields::ExtraFieldId;
 use rawzip::time::{LocalDateTime, UtcDateTime, ZipDateTimeKind};
-use rawzip::{Error, ErrorKind, ZipArchive, ZipArchiveWriter};
+use rawzip::{CreatorSystem, Error, ErrorKind, ZipArchive, ZipArchiveWriter};
 use std::cell::Cell;
 use std::fs::File;
 use std::io::{Cursor, Read, Seek, SeekFrom};
@@ -52,6 +52,7 @@ struct ZipTestFileEntry {
     expected_content: ExpectedContent,
     expected_datetime: Option<ZipDateTimeKind>,
     expected_mode: Option<u32>,
+    expected_creator_system: Option<CreatorSystem>,
 }
 
 #[derive(Debug)]
@@ -74,6 +75,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 2, 12, 1, 0).unwrap()
                 )), // 2010-09-05 02:12:01 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "gophercolor16x16.png",
@@ -82,6 +84,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 5, 52, 58, 0).unwrap()
                 )), // 2010-09-05 05:52:58 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -110,6 +113,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 2, 12, 1, 0).unwrap()
                 )), // 2010-09-05 02:12:01 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "gophercolor16x16.png",
@@ -118,6 +122,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 5, 52, 58, 0).unwrap()
                 )), // 2010-09-05 05:52:58 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -137,6 +142,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 2, 12, 1, 0).unwrap()
                 )), // 2010-09-05 02:12:01 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "gophercolor16x16.png",
@@ -145,6 +151,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 5, 52, 58, 0).unwrap()
                 )), // 2010-09-05 05:52:58 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -162,6 +169,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2012, 2, 3, 21, 56, 48, 0).unwrap()
             )), // 2012-02-03 21:56:48 (UTC from archive)
             expected_mode: Some(0o120777), // Symlink with 777 permissions
+            expected_creator_system: Some(CreatorSystem::UNIX),
         }],
         ..Default::default()
     }
@@ -178,7 +186,7 @@ zip_test_case!(
 zip_test_case!(
     "winxp",
     ZipTestCase {
-        // created in windows XP file manager.
+        // Created in the Windows XP file manager
         name: "winxp.zip",
         files: vec![
             ZipTestFileEntry {
@@ -188,6 +196,7 @@ zip_test_case!(
                     LocalDateTime::from_components(2011, 12, 8, 10, 4, 24, 0).unwrap()
                 )),
                 expected_mode: Some(0o100666), // Regular file with 666 permissions (Windows)
+                expected_creator_system: Some(CreatorSystem::MVS),
             },
             ZipTestFileEntry {
                 name: "dir/bar",
@@ -196,6 +205,7 @@ zip_test_case!(
                     LocalDateTime::from_components(2011, 12, 8, 10, 4, 50, 0).unwrap()
                 )),
                 expected_mode: Some(0o100666), // Regular file with 666 permissions (Windows)
+                expected_creator_system: Some(CreatorSystem::MVS),
             },
             ZipTestFileEntry {
                 name: "dir/empty/",
@@ -204,6 +214,7 @@ zip_test_case!(
                     LocalDateTime::from_components(2011, 12, 8, 10, 8, 6, 0).unwrap()
                 )),
                 expected_mode: Some(0o040777), // Directory with 777 permissions (Windows)
+                expected_creator_system: Some(CreatorSystem::MVS),
             },
             ZipTestFileEntry {
                 name: "readonly",
@@ -212,6 +223,7 @@ zip_test_case!(
                     LocalDateTime::from_components(2011, 12, 8, 10, 6, 8, 0).unwrap()
                 )),
                 expected_mode: Some(0o100444), // Read-only file (Windows)
+                expected_creator_system: Some(CreatorSystem::MVS),
             },
         ],
         ..Default::default()
@@ -231,6 +243,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2011, 12, 8, 10, 4, 24, 0).unwrap()
                 )), // 2011-12-08 10:04:24 UTC (but stored as local time)
                 expected_mode: Some(0o100666), // Regular file with 666 permissions (Unix)
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "dir/bar",
@@ -239,6 +252,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2011, 12, 8, 10, 4, 50, 0).unwrap()
                 )), // 2011-12-08 10:04:50 UTC (but stored as local time)
                 expected_mode: Some(0o100666), // Regular file with 666 permissions (Unix)
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "dir/empty/",
@@ -247,6 +261,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2011, 12, 8, 10, 8, 6, 0).unwrap()
                 )), // 2011-12-08 10:08:06 UTC (but stored as local time)
                 expected_mode: Some(0o040777), // Directory with 777 permissions (Unix)
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "readonly",
@@ -255,6 +270,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2011, 12, 8, 10, 6, 8, 0).unwrap()
                 )), // 2011-12-08 10:06:08 UTC (but stored as local time)
                 expected_mode: Some(0o100444), // Read-only file (Unix)
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -275,6 +291,7 @@ zip_test_case!(
                     LocalDateTime::from_components(1980, 1, 1, 0, 0, 0, 0).unwrap()
                 )), // DOS timestamp 0x0000 0x0000 normalized to 1980-01-01 00:00:00
                 expected_mode: Some(0o100666), // Regular file with 666 permissions
+                expected_creator_system: Some(CreatorSystem::FAT),
             },
             ZipTestFileEntry {
                 name: "bar.txt",
@@ -283,6 +300,7 @@ zip_test_case!(
                     LocalDateTime::from_components(1980, 1, 1, 0, 0, 0, 0).unwrap()
                 )), // DOS timestamp 0x0000 0x0000 normalized to 1980-01-01 00:00:00
                 expected_mode: Some(0o100666), // Regular file with 666 permissions
+                expected_creator_system: Some(CreatorSystem::FAT),
             },
         ],
         ..Default::default()
@@ -301,6 +319,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2012, 3, 9, 0, 59, 10, 0).unwrap()
                 )), // 2012-03-09 00:59:10 (UTC from archive)
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "bar.txt",
@@ -309,6 +328,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2012, 3, 9, 0, 59, 12, 0).unwrap()
                 )), // 2012-03-09 00:59:12 (UTC from archive)
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -328,6 +348,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2012, 8, 10, 18, 33, 32, 0).unwrap()
             )), // 2012-08-10 18:33:32 (UTC from archive)
             expected_mode: Some(0o100644), // Regular file with 644 permissions
+            expected_creator_system: Some(CreatorSystem::UNIX),
         }],
         ..Default::default()
     }
@@ -344,6 +365,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 244817900).unwrap()
             )), // 2017-10-31 21:11:57.244817900 (-7 hours) = 2017-11-01 04:11:57.244817900 UTC
             expected_mode: Some(0o100666), // Regular file with 666 permissions
+            expected_creator_system: Some(CreatorSystem::FAT),
         }],
         ..Default::default()
     }
@@ -360,6 +382,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 0).unwrap()
             )), // 2017-10-31 21:11:57.000 (-7 hours) = 2017-11-01 04:11:57.000 UTC
             expected_mode: Some(0o100644), // Regular file with 644 permissions
+            expected_creator_system: Some(CreatorSystem::UNIX),
         }],
         ..Default::default()
     }
@@ -376,6 +399,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 0).unwrap()
             )), // 2017-10-31 21:11:57.000 (-7 hours) = 2017-11-01 04:11:57.000 UTC
             expected_mode: Some(0o100644), // Regular file with 644 permissions
+            expected_creator_system: Some(CreatorSystem::UNIX),
         }],
         ..Default::default()
     }
@@ -392,6 +416,7 @@ zip_test_case!(
                 LocalDateTime::from_components(2017, 10, 31, 21, 11, 58, 0).unwrap()
             )), // 2017-10-31 21:11:58.000 (DOS local time)
             expected_mode: Some(0o100666), // Regular file with 666 permissions
+            expected_creator_system: Some(CreatorSystem::FAT),
         }],
         ..Default::default()
     }
@@ -408,6 +433,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 244817900).unwrap()
             )), // 2017-10-31 21:11:57.244817900 (-7 hours) = 2017-11-01 04:11:57.244817900 UTC
             expected_mode: Some(0o100666), // Regular file with 666 permissions
+            expected_creator_system: Some(CreatorSystem::FAT),
         }],
         ..Default::default()
     }
@@ -424,6 +450,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 244000000).unwrap()
             )), // 2017-10-31 21:11:57.244000000 (-7 hours) = 2017-11-01 04:11:57.244000000 UTC
             expected_mode: Some(0o100666), // Regular file with 666 permissions
+            expected_creator_system: Some(CreatorSystem::FAT),
         }],
         ..Default::default()
     }
@@ -440,6 +467,7 @@ zip_test_case!(
                 UtcDateTime::from_components(2017, 11, 1, 4, 11, 57, 0).unwrap()
             )), // 2017-10-31 21:11:57.000 (-7 hours) = 2017-11-01 04:11:57.000 UTC
             expected_mode: Some(0o100666), // Regular file with 666 permissions
+            expected_creator_system: Some(CreatorSystem::FAT),
         }],
         ..Default::default()
     }
@@ -458,6 +486,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 2, 12, 1, 0).unwrap()
                 )), // 2010-09-05 02:12:01 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "gophercolor16x16.png",
@@ -466,6 +495,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 5, 52, 58, 0).unwrap()
                 )), // 2010-09-05 05:52:58 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -485,6 +515,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 2, 12, 1, 0).unwrap()
                 )), // 2010-09-05 02:12:01 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
             ZipTestFileEntry {
                 name: "gophercolor16x16.png",
@@ -493,6 +524,7 @@ zip_test_case!(
                     UtcDateTime::from_components(2010, 9, 5, 5, 52, 58, 0).unwrap()
                 )), // 2010-09-05 05:52:58 UTC
                 expected_mode: Some(0o100644), // Regular file with 644 permissions
+                expected_creator_system: Some(CreatorSystem::UNIX),
             },
         ],
         ..Default::default()
@@ -544,6 +576,15 @@ fn process_archive_files<R: rawzip::ReaderAt>(
                                 actual_mode, expected_mode,
                                 "Mode mismatch for file {}: expected 0o{:o}, got 0o{:o}",
                                 expected_file.name, expected_mode, actual_mode
+                            );
+                        }
+
+                        if let Some(expected_creator) = expected_file.expected_creator_system {
+                            let actual_creator = entry.version_made_by().creator_system();
+                            assert_eq!(
+                                actual_creator, expected_creator,
+                                "Creator system mismatch for file {}: expected {:?}, got {:?}",
+                                expected_file.name, expected_creator, actual_creator
                             );
                         }
 
@@ -651,6 +692,15 @@ fn process_slice_archive_files(
                                 actual_mode, expected_mode,
                                 "Mode mismatch for file {}: expected 0o{:o}, got 0o{:o}",
                                 expected_file.name, expected_mode, actual_mode
+                            );
+                        }
+
+                        if let Some(expected_creator) = expected_file.expected_creator_system {
+                            let actual_creator = entry.version_made_by().creator_system();
+                            assert_eq!(
+                                actual_creator, expected_creator,
+                                "Creator system mismatch for file {}: expected {:?}, got {:?}",
+                                expected_file.name, expected_creator, actual_creator
                             );
                         }
 

--- a/tests/it/permission_tests.rs
+++ b/tests/it/permission_tests.rs
@@ -1,4 +1,4 @@
-use rawzip::{ZipArchive, ZipArchiveWriter};
+use rawzip::{CreatorSystem, ZipArchive, ZipArchiveWriter};
 use std::io::Write;
 
 #[test]
@@ -48,6 +48,19 @@ fn test_unix_permissions_roundtrip() {
         assert_eq!(
             actual_mode, expected_mode,
             "{description}: expected permissions 0o{expected_mode:o}, got 0o{actual_mode:o}"
+        );
+
+        // Unix permissions are recorded as a UNIX creator system with the mode
+        // in the upper 16 bits of the external attributes.
+        assert_eq!(
+            entry.version_made_by().creator_system(),
+            CreatorSystem::UNIX,
+            "{description}: expected UNIX creator system"
+        );
+        assert_eq!(
+            entry.external_attributes() >> 16,
+            permissions,
+            "{description}: external attributes should carry the unix mode"
         );
     }
 }
@@ -115,4 +128,9 @@ fn test_permissions_without_unix_permissions() {
         actual_mode, 0o100666,
         "Default permissions: expected 0o100666, got 0o{actual_mode:o}"
     );
+
+    // Without unix permissions the writer falls back to a FAT creator system
+    // and empty external attributes.
+    assert_eq!(entry.version_made_by().creator_system(), CreatorSystem::FAT);
+    assert_eq!(entry.external_attributes(), 0);
 }


### PR DESCRIPTION
Closes #174

Uncreatable enum could be replaced with a mod, but naming rules would be different.