### PR TITLE
Add required buffer capacity to buffer too small error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The reason is to prevent breaking changes in the future by properly modeling unk
 - Relocate `ZipSliceEntry::{file_path,extra_fields}` behind lifetime accurate `ZipSliceEntry::local_header`
 - Seal `TimeZoneMarker` trait
 - Remove deprecated `ZipFileBuilder::create`
+- Change `ErrorKind::BufferTooSmall` to carry the required buffer capacity
 
 ### Performance
 

--- a/fuzz/fuzz_targets/fuzz_zip.rs
+++ b/fuzz/fuzz_targets/fuzz_zip.rs
@@ -161,7 +161,10 @@ fn errors_eq(a: &Error, b: &ErrorKind) -> bool {
         (ErrorKind::Eof, ErrorKind::Eof) => true,
         (ErrorKind::MissingEndOfCentralDirectory, ErrorKind::MissingEndOfCentralDirectory) => true,
         (ErrorKind::InvalidEndOfCentralDirectory, ErrorKind::InvalidEndOfCentralDirectory) => true,
-        (ErrorKind::BufferTooSmall, ErrorKind::BufferTooSmall) => true,
+        (
+            ErrorKind::BufferTooSmall { required: a },
+            ErrorKind::BufferTooSmall { required: b },
+        ) => a == b,
         _ => false,
     }
 }

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -390,7 +390,9 @@ where
 
         // Check if buffer is large enough for both filename and extra fields
         if buffer.len() < total_variable_len {
-            return Err(Error::from(ErrorKind::BufferTooSmall));
+            return Err(Error::from(ErrorKind::BufferTooSmall {
+                required: total_variable_len,
+            }));
         }
 
         let variable_data = &mut buffer[..total_variable_len];
@@ -558,6 +560,21 @@ where
         if self.pos + variable_length > self.end {
             // Need to read more data
             let remaining = self.end - self.pos;
+
+            // The buffer can never hold this record's variable section.
+            if variable_length > self.buffer.len() {
+                return Err(Error::from(ErrorKind::BufferTooSmall {
+                    required: variable_length,
+                }));
+            }
+
+            // The variable section runs past the end of the central directory,
+            // so the archive is truncated or corrupt.
+            let cd_remaining = remaining + (self.central_dir_end_pos - self.offset) as usize;
+            if variable_length > cd_remaining {
+                return Err(Error::from(ErrorKind::Eof));
+            }
+
             self.buffer.copy_within(self.pos..self.end, 0);
             let max_read = ((self.central_dir_end_pos - self.offset) as usize)
                 .min(self.buffer.len() - remaining);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,8 +70,12 @@ pub enum ErrorKind {
     /// Missing end of central directory
     MissingEndOfCentralDirectory,
 
-    /// Buffer size too small
-    BufferTooSmall,
+    /// Buffer size too small for the required capacity
+    ///
+    /// [`crate::RECOMMENDED_BUFFER_SIZE`] is suitable for normal archive
+    /// reading. A buffer sized to [`crate::MAX_CENTRAL_DIRECTORY_RECORD_SIZE`]
+    /// will never yield this error.
+    BufferTooSmall { required: usize },
 
     /// Invalid end of central directory signature
     InvalidSignature { expected: u32, actual: u32 },
@@ -128,8 +132,8 @@ impl core::fmt::Display for ErrorKind {
             ErrorKind::MissingEndOfCentralDirectory => {
                 write!(f, "Missing end of central directory")
             }
-            ErrorKind::BufferTooSmall => {
-                write!(f, "Buffer size too small")
+            ErrorKind::BufferTooSmall { required } => {
+                write!(f, "Buffer size too small: required {required} bytes")
             }
             ErrorKind::Eof => {
                 write!(f, "Unexpected end of file")

--- a/src/reader_at.rs
+++ b/src/reader_at.rs
@@ -77,7 +77,7 @@ impl<T: ReaderAt> ReaderAtExt for T {
         offset: u64,
     ) -> Result<usize, Error> {
         if buffer.len() < size {
-            return Err(Error::from(ErrorKind::BufferTooSmall));
+            return Err(Error::from(ErrorKind::BufferTooSmall { required: size }));
         }
 
         let read = self.try_read_at_least_at(buffer, size, offset)?;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -815,7 +815,9 @@ fn errors_eq(a: &Error, b: &ErrorKind) -> bool {
         (ErrorKind::IO(a), ErrorKind::IO(b)) => a.kind() == b.kind(),
         (ErrorKind::Eof, ErrorKind::Eof) => true,
         (ErrorKind::MissingEndOfCentralDirectory, ErrorKind::MissingEndOfCentralDirectory) => true,
-        (ErrorKind::BufferTooSmall, ErrorKind::BufferTooSmall) => true,
+        (ErrorKind::BufferTooSmall { required: a }, ErrorKind::BufferTooSmall { required: b }) => {
+            a == b
+        }
         _ => false,
     }
 }
@@ -1243,6 +1245,7 @@ fn oversized_entry_needs_max_central_directory_buffer() {
     let name = "a".repeat(u16::MAX as usize);
     let comment = vec![b'c'; u16::MAX as usize];
     let extra = vec![0u8; u16::MAX as usize - 4];
+    let expected_required = name.len() + 4 + extra.len() + comment.len();
     let mut output = Vec::new();
     let mut writer = ZipArchiveWriter::new(&mut output);
     let (entry, config) = writer
@@ -1264,7 +1267,13 @@ fn oversized_entry_needs_max_central_directory_buffer() {
         .unwrap();
     let mut entries = archive.entries(&mut small);
     let err = entries.next_entry().unwrap_err();
-    assert!(matches!(err.kind(), rawzip::ErrorKind::BufferTooSmall));
+    assert!(matches!(
+        err.kind(),
+        rawzip::ErrorKind::BufferTooSmall {
+            required: required_variable_len
+        }
+        if *required_variable_len == expected_required
+    ));
 
     // A buffer sized to MAX_CENTRAL_DIRECTORY_RECORD_SIZE parses it.
     let mut large = vec![0u8; rawzip::MAX_CENTRAL_DIRECTORY_RECORD_SIZE];
@@ -1281,4 +1290,39 @@ fn oversized_entry_needs_max_central_directory_buffer() {
     let mut slice_entries = slice_archive.entries();
     let slice_entry = slice_entries.next_entry().unwrap().expect("entry present");
     assert_eq!(slice_entry.file_path().as_bytes().len(), u16::MAX as usize);
+}
+
+#[test]
+fn entry_overrunning_central_directory_is_eof() {
+    let mut output = Vec::new();
+    let mut writer = ZipArchiveWriter::new(&mut output);
+    let (entry, config) = writer
+        .new_file("hello.txt")
+        .compression_method(rawzip::CompressionMethod::STORE)
+        .start()
+        .unwrap();
+    let (entry, descriptor) = config.wrap(entry).finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    writer.finish().unwrap();
+
+    // A buffer large enough to hold the (bogus) record rules out BufferTooSmall,
+    // so only the overrun can be at fault.
+    let mut buf = vec![0u8; rawzip::MAX_CENTRAL_DIRECTORY_RECORD_SIZE];
+    let cd_offset = rawzip::ZipLocator::new()
+        .locate_in_reader(output.as_slice(), &mut buf, output.len() as u64)
+        .unwrap()
+        .directory_offset() as usize;
+
+    // Inflate the entry's file name length (28 bytes into the central directory
+    // header) so its variable section claims far more bytes than the central
+    // directory actually holds.
+    let name_len_pos = cd_offset + 28;
+    output[name_len_pos..name_len_pos + 2].copy_from_slice(&u16::MAX.to_le_bytes());
+
+    let archive = rawzip::ZipLocator::new()
+        .locate_in_reader(output.as_slice(), &mut buf, output.len() as u64)
+        .unwrap();
+    let mut entries = archive.entries(&mut buf);
+    let err = entries.next_entry().unwrap_err();
+    assert!(matches!(err.kind(), rawzip::ErrorKind::Eof));
 }


### PR DESCRIPTION
This provides much more useful context when the user supplied buffer isn't big enough to handle a read