### PR TITLE
Set MS-DOS directory attribute for written dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The reason is to prevent breaking changes in the future by properly modeling unk
 - Fix `ZipEntry::local_header` panic if underlying file content changes
 - Fix manual `UtcDateTime::from_unix` construction for negative Unix timestamps
 - Update display and debug implementations for `CompressionMethod`
+- Set the MS-DOS directory attribute in the external file attributes of written directory entries
 
 ## v0.4.4 - March 9th, 2026
 

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -151,7 +151,7 @@ const S_ISGID: u32 = 0o002000; // Set group ID
 const S_ISVTX: u32 = 0o001000; // Sticky bit
 
 /// MSDOS file attribute constants
-const MSDOS_DIR: u32 = 0x10;
+pub(crate) const MSDOS_DIR: u32 = 0x10;
 const MSDOS_READONLY: u32 = 0x01;
 
 /// Converts Unix mode to file mode

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,7 +5,7 @@ use crate::{
     ZipLocalFileHeaderFixed,
     errors::ErrorKind,
     extra_fields::{ExtraFieldId, ExtraFieldsContainer},
-    mode::{CreatorSystem, VersionMadeBy},
+    mode::{CreatorSystem, MSDOS_DIR, VersionMadeBy},
     path::{EntryPath, EntryPathInner, ZipFilePath, str_needs_utf8},
     time::{DosDateTime, UtcDateTime},
 };
@@ -868,6 +868,13 @@ where
 
         // Write central directory entries
         for file in &self.files {
+            let new_name_offset = name_offset + file.name_len as usize;
+            let file_name = &self.file_names[name_offset..new_name_offset];
+
+            let is_dir = ZipFilePath::from_bytes(file_name).is_dir();
+            let external_file_attrs = file.unix_permissions.map(|x| x << 16).unwrap_or(0)
+                | if is_dir { MSDOS_DIR } else { 0 };
+
             // Version made by and version needed to extract
             let version_needed = if file.needs_zip64() {
                 ZIP64_VERSION_NEEDED
@@ -904,16 +911,14 @@ where
                 file_comment_len: file.file_comment_len,
                 disk_number_start: 0,
                 internal_file_attrs: 0,
-                external_file_attrs: file.unix_permissions.map(|x| x << 16).unwrap_or(0),
+                external_file_attrs,
                 local_header_offset: file.local_header_offset.min(ZIP64_THRESHOLD_OFFSET) as u32,
             };
 
             header.write(&mut self.writer)?;
 
             // File name
-            let new_name_offset = name_offset + file.name_len as usize;
-            self.writer
-                .write_all(&self.file_names[name_offset..new_name_offset])?;
+            self.writer.write_all(file_name)?;
             name_offset = new_name_offset;
 
             // Extra fields

--- a/tests/it/permission_tests.rs
+++ b/tests/it/permission_tests.rs
@@ -97,6 +97,29 @@ fn test_directory_permissions_roundtrip() {
         actual_mode, 0o040755,
         "Directory permissions: expected 0o040755, got 0o{actual_mode:o}"
     );
+
+    assert_eq!(entry.external_attributes() & 0x10, 0x10);
+}
+
+#[test]
+fn test_directory_without_unix_permissions_has_msdos_directory_attribute() {
+    let mut output = Vec::new();
+    let mut archive = ZipArchiveWriter::new(&mut output);
+    archive.new_dir("test_dir/").create().unwrap();
+    archive.finish().unwrap();
+
+    let archive = ZipArchive::from_slice(&output).unwrap();
+    let mut entries = archive.entries();
+    let entry = entries.next_entry().unwrap().unwrap();
+
+    assert!(entry.is_dir());
+    assert_eq!(entry.external_attributes() & 0x10, 0x10);
+
+    let actual_mode = entry.mode().value();
+    assert_eq!(
+        actual_mode, 0o040777,
+        "Directory mode: expected 0o040777, got 0o{actual_mode:o}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Prior art:

- python zipfile
- go archive/zip
- minizip-ng
- 7-zip