### PR TITLE
Feature: DataDescriptorOutput constructor

### DIFF
--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -1,0 +1,129 @@
+//! Copy compressed file's data **verbatim** from one archive to another — no
+//! decompression, no re-compression. Each entry's already-compressed bytes are
+//! read from the source and written straight to the destination, preserving the
+//! original compression method, using `DataDescriptorOutput::new` to supply the
+//! known CRC and uncompressed size.
+//!
+//! This is the fast path for tools that rewrite an archive while leaving most
+//! entries untouched (adding, removing, or replacing a few files): the bulk of
+//! the data is copied through without ever being inflated.
+//!
+//! Run: `cargo run --example passthrough`
+
+use std::io::Write;
+
+use rawzip::{CompressionMethod, DataDescriptorOutput, ZipArchive, ZipArchiveWriter};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Build a small source archive with a Deflate-compressed entry and a
+    //    Stored entry, so the copy exercises both.
+    let source = build_source()?;
+
+    // 2. Copy every entry raw into a fresh archive.
+    let copied = copy_verbatim(&source)?;
+
+    // 3. Verify: the copy decodes to the same content, entry for entry.
+    verify(&source, &copied)?;
+
+    println!("passthrough copy verified: {} bytes -> {} bytes", source.len(), copied.len());
+    Ok(())
+}
+
+fn build_source() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut out = std::io::Cursor::new(Vec::new());
+    let mut archive = ZipArchiveWriter::new(&mut out);
+
+    // Deflate entry.
+    let (mut entry, config) = archive
+        .new_file("deflated.txt")
+        .compression_method(CompressionMethod::DEFLATE)
+        .start()?;
+    let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
+    let mut writer = config.wrap(encoder);
+    writer.write_all(b"the quick brown fox jumps over the lazy dog\n".repeat(64).as_slice())?;
+    let (encoder, desc) = writer.finish()?;
+    encoder.finish()?;
+    entry.finish(desc)?;
+
+    // Stored entry.
+    let (mut entry, config) = archive
+        .new_file("stored.bin")
+        .compression_method(CompressionMethod::STORE)
+        .start()?;
+    let mut writer = config.wrap(&mut entry);
+    writer.write_all(b"raw stored bytes")?;
+    let (_, desc) = writer.finish()?;
+    entry.finish(desc)?;
+
+    archive.finish()?;
+    Ok(out.into_inner())
+}
+
+fn copy_verbatim(source: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let archive = ZipArchive::from_slice(source)?;
+    let mut out = std::io::Cursor::new(Vec::new());
+    let mut writer = ZipArchiveWriter::new(&mut out);
+
+    let mut entries = archive.entries();
+    while let Some(dir) = entries.next_entry()? {
+        if dir.is_dir() {
+            continue;
+        }
+        // Read the entry's metadata + raw (still-compressed) bytes.
+        let name = dir.file_path().try_normalize()?.as_ref().to_string();
+        let crc = dir.crc32();
+        let uncompressed_size = dir.uncompressed_size_hint();
+        let method = dir.compression_method();
+        let local = archive.get_entry(dir.wayfinder())?;
+        let raw = local.data();
+
+        // Write those bytes straight through — no compressor — declaring the
+        // original method and the known CRC + uncompressed size.
+        let (mut entry, _config) = writer
+            .new_file(name.as_str())
+            .compression_method(method)
+            .start()?;
+        entry.write_all(raw)?;
+        entry.finish(DataDescriptorOutput::new(crc, uncompressed_size))?;
+    }
+
+    writer.finish()?;
+    Ok(out.into_inner())
+}
+
+/// A decoded archive: (entry name, uncompressed content) per file entry.
+type Decoded = Vec<(String, Vec<u8>)>;
+
+fn verify(source: &[u8], copied: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    let a = decode_all(source)?;
+    let b = decode_all(copied)?;
+    assert_eq!(a, b, "copied archive content differs from source");
+    Ok(())
+}
+
+/// Decompress every file entry of `bytes` to (name, content), verifying each
+/// entry's CRC via `verifying_reader`.
+fn decode_all(bytes: &[u8]) -> Result<Decoded, Box<dyn std::error::Error>> {
+    let archive = ZipArchive::from_slice(bytes)?;
+    let mut entries = archive.entries();
+    let mut result = Vec::new();
+    while let Some(dir) = entries.next_entry()? {
+        if dir.is_dir() {
+            continue;
+        }
+        let name = dir.file_path().try_normalize()?.as_ref().to_string();
+        let entry = archive.get_entry(dir.wayfinder())?;
+        let decoder: Box<dyn std::io::Read> = match dir.compression_method() {
+            CompressionMethod::STORE => Box::new(entry.data()),
+            CompressionMethod::DEFLATE => {
+                Box::new(flate2::bufread::DeflateDecoder::new(entry.data()))
+            }
+            other => return Err(format!("unexpected method {other:?}").into()),
+        };
+        let mut verifier = entry.verifying_reader(decoder);
+        let mut content = Vec::new();
+        std::io::copy(&mut verifier, &mut content)?;
+        result.push((name, content));
+    }
+    Ok(result)
+}

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -25,7 +25,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 3. Verify: the copy decodes to the same content, entry for entry.
     verify(&source, &copied)?;
 
-    println!("passthrough copy verified: {} bytes -> {} bytes", source.len(), copied.len());
+    println!(
+        "passthrough copy verified: {} bytes -> {} bytes",
+        source.len(),
+        copied.len()
+    );
     Ok(())
 }
 
@@ -40,7 +44,11 @@ fn build_source() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         .start()?;
     let encoder = flate2::write::DeflateEncoder::new(&mut entry, flate2::Compression::default());
     let mut writer = config.wrap(encoder);
-    writer.write_all(b"the quick brown fox jumps over the lazy dog\n".repeat(64).as_slice())?;
+    writer.write_all(
+        b"the quick brown fox jumps over the lazy dog\n"
+            .repeat(64)
+            .as_slice(),
+    )?;
     let (encoder, desc) = writer.finish()?;
     encoder.finish()?;
     entry.finish(desc)?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1234,6 +1234,67 @@ impl DataDescriptorOutput {
     ///
     /// The `compressed_size` is not taken here: [`ZipEntryWriter::finish`]
     /// overwrites it with the number of bytes actually written to the entry.
+    ///
+    /// # Example: copy an entry verbatim between archives
+    ///
+    /// Read an entry's raw (still-compressed) bytes plus its CRC and
+    /// uncompressed size from a source archive, and write them straight into a
+    /// new archive — no decompression or re-compression. The entry's original
+    /// compression method is preserved on the destination.
+    ///
+    /// ```rust
+    /// # use std::io::Write;
+    /// # use rawzip::{
+    /// #     CompressionMethod, DataDescriptorOutput, ZipArchive, ZipArchiveWriter,
+    /// # };
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // A source archive with one entry (Stored here for a dependency-free
+    /// // example; the same works for any compression method).
+    /// let mut src = std::io::Cursor::new(Vec::new());
+    /// let mut sw = ZipArchiveWriter::new(&mut src);
+    /// let (mut e, config) = sw
+    ///     .new_file("hello.txt")
+    ///     .compression_method(CompressionMethod::STORE)
+    ///     .start()?;
+    /// let mut w = config.wrap(&mut e);
+    /// w.write_all(b"Hello, world!")?;
+    /// let (_, desc) = w.finish()?;
+    /// e.finish(desc)?;
+    /// sw.finish()?;
+    /// let src = src.into_inner();
+    ///
+    /// // Read the source entry's metadata + raw compressed bytes.
+    /// let archive = ZipArchive::from_slice(&src)?;
+    /// let mut entries = archive.entries();
+    /// let dir = entries.next_entry()?.expect("one entry");
+    /// let crc = dir.crc32();
+    /// let uncompressed_size = dir.uncompressed_size_hint();
+    /// let method = dir.compression_method();
+    /// let local = archive.get_entry(dir.wayfinder())?;
+    /// let raw = local.data();
+    ///
+    /// // Copy those raw bytes into a new archive with no re-compression,
+    /// // supplying the known CRC + uncompressed size via `DataDescriptorOutput::new`.
+    /// let mut dst = std::io::Cursor::new(Vec::new());
+    /// let mut dw = ZipArchiveWriter::new(&mut dst);
+    /// let (mut out, _config) = dw
+    ///     .new_file("hello.txt")
+    ///     .compression_method(method)
+    ///     .start()?;
+    /// out.write_all(raw)?;
+    /// out.finish(DataDescriptorOutput::new(crc, uncompressed_size))?;
+    /// dw.finish()?;
+    ///
+    /// // The copy round-trips: same CRC and uncompressed size.
+    /// let dst = dst.into_inner();
+    /// let copied = ZipArchive::from_slice(&dst)?;
+    /// let mut it = copied.entries();
+    /// let e = it.next_entry()?.expect("one entry");
+    /// assert_eq!(e.crc32(), crc);
+    /// assert_eq!(e.uncompressed_size_hint(), uncompressed_size);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(crc: u32, uncompressed_size: u64) -> Self {
         DataDescriptorOutput {
             crc,
@@ -1837,7 +1898,7 @@ mod tests {
         let src_uncompressed = dir_entry.uncompressed_size_hint();
         let wayfinder = dir_entry.wayfinder();
         let src_local = src_archive.get_entry(wayfinder).unwrap();
-        let raw_compressed = src_local.data().to_vec();
+        let raw_compressed = src_local.data();
 
         // Copy the raw compressed bytes verbatim into a new archive, supplying
         // the known CRC + uncompressed size via DataDescriptorOutput::new.
@@ -1849,7 +1910,7 @@ mod tests {
                 .compression_method(CompressionMethod::DEFLATE)
                 .start()
                 .unwrap();
-            entry.write_all(&raw_compressed).unwrap();
+            entry.write_all(raw_compressed).unwrap();
             entry
                 .finish(DataDescriptorOutput::new(src_crc, src_uncompressed))
                 .unwrap();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1223,6 +1223,25 @@ pub struct DataDescriptorOutput {
 }
 
 impl DataDescriptorOutput {
+    /// Constructs a `DataDescriptorOutput` from a known CRC32 and uncompressed
+    /// size.
+    ///
+    /// This is for callers that write **already-compressed** bytes directly to
+    /// a [`ZipEntryWriter`] (e.g. copying an entry verbatim from one archive to
+    /// another without re-compressing) and therefore cannot obtain the
+    /// descriptor from [`ZipDataWriter::finish`], which derives these values by
+    /// running the *uncompressed* data through a hasher.
+    ///
+    /// The `compressed_size` is not taken here: [`ZipEntryWriter::finish`]
+    /// overwrites it with the number of bytes actually written to the entry.
+    pub fn new(crc: u32, uncompressed_size: u64) -> Self {
+        DataDescriptorOutput {
+            crc,
+            compressed_size: 0,
+            uncompressed_size,
+        }
+    }
+
     /// Returns the CRC32 checksum of the uncompressed data.
     pub fn crc(&self) -> u32 {
         self.crc
@@ -1781,5 +1800,74 @@ mod tests {
         archive.set_comment(too_long);
 
         assert!(archive.finish().is_err());
+    }
+
+    #[test]
+    fn test_raw_passthrough_with_data_descriptor_output_new() {
+        use flate2::write::DeflateEncoder;
+        use std::io::Write;
+
+        let data = b"the quick brown fox jumps over the lazy dog";
+
+        // Build a source archive with one Deflate-compressed entry.
+        let mut src = Cursor::new(Vec::new());
+        {
+            let mut archive = ZipArchiveWriter::new(&mut src);
+            let (mut entry, config) = archive
+                .new_file("src.txt")
+                .compression_method(CompressionMethod::DEFLATE)
+                .start()
+                .unwrap();
+            let mut writer = config.wrap(DeflateEncoder::new(
+                &mut entry,
+                flate2::Compression::default(),
+            ));
+            writer.write_all(data).unwrap();
+            let (_, descriptor) = writer.finish().unwrap();
+            entry.finish(descriptor).unwrap();
+            archive.finish().unwrap();
+        }
+        let src_bytes = src.into_inner();
+
+        // Read the source entry's raw (still-compressed) bytes + metadata.
+        let src_archive = ZipArchive::from_slice(&src_bytes).unwrap();
+        let mut entries = src_archive.entries();
+        let dir_entry = entries.next_entry().unwrap().unwrap();
+        let src_crc = dir_entry.crc32();
+        let src_uncompressed = dir_entry.uncompressed_size_hint();
+        let wayfinder = dir_entry.wayfinder();
+        let src_local = src_archive.get_entry(wayfinder).unwrap();
+        let raw_compressed = src_local.data().to_vec();
+
+        // Copy the raw compressed bytes verbatim into a new archive, supplying
+        // the known CRC + uncompressed size via DataDescriptorOutput::new.
+        let mut dst = Cursor::new(Vec::new());
+        {
+            let mut archive = ZipArchiveWriter::new(&mut dst);
+            let (mut entry, _config) = archive
+                .new_file("copy.txt")
+                .compression_method(CompressionMethod::DEFLATE)
+                .start()
+                .unwrap();
+            entry.write_all(&raw_compressed).unwrap();
+            entry
+                .finish(DataDescriptorOutput::new(src_crc, src_uncompressed))
+                .unwrap();
+            archive.finish().unwrap();
+        }
+        let dst_bytes = dst.into_inner();
+
+        // The copied entry must decode back to the original data and verify.
+        let dst_archive = ZipArchive::from_slice(&dst_bytes).unwrap();
+        let mut dst_entries = dst_archive.entries();
+        let dst_dir = dst_entries.next_entry().unwrap().unwrap();
+        assert_eq!(dst_dir.crc32(), src_crc);
+        assert_eq!(dst_dir.uncompressed_size_hint(), src_uncompressed);
+        let dst_local = dst_archive.get_entry(dst_dir.wayfinder()).unwrap();
+        let mut verifier = dst_local
+            .verifying_reader(flate2::bufread::DeflateDecoder::new(dst_local.data()));
+        let mut actual = Vec::new();
+        std::io::copy(&mut verifier, &mut actual).unwrap();
+        assert_eq!(&actual, data);
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1925,8 +1925,8 @@ mod tests {
         assert_eq!(dst_dir.crc32(), src_crc);
         assert_eq!(dst_dir.uncompressed_size_hint(), src_uncompressed);
         let dst_local = dst_archive.get_entry(dst_dir.wayfinder()).unwrap();
-        let mut verifier = dst_local
-            .verifying_reader(flate2::bufread::DeflateDecoder::new(dst_local.data()));
+        let mut verifier =
+            dst_local.verifying_reader(flate2::bufread::DeflateDecoder::new(dst_local.data()));
         let mut actual = Vec::new();
         std::io::copy(&mut verifier, &mut actual).unwrap();
         assert_eq!(&actual, data);


### PR DESCRIPTION
This PR adds a public constructor for DataDescriptorOutput structure, allowing for pass-through already-compressed zip entries from one archive to another, thus avoiding the need to decompress and re-compress all the data when you only want to change some files in a large archive.
The PR also contains examples of how to use this flow.

Related to #67 — although allows the flow using a smaller workaround rather than a first-class separate API.