### PR TITLE
Rename prev deprecated into_reader to into_reader_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The reason is to prevent breaking changes in the future by properly modeling unk
 - Remove accidentally exposed (and unused) `StackVecIter`
 - Remove redundant getters on `ZipVerification`
 - Remove `ZipSliceArchive::as_bytes` as `get_ref` is strictly better
-- Un-deprecate `ZipSliceArchive::into_reader`, now constrained to `T: ReaderAt`
+- Undeprecate `ZipSliceArchive::into_reader` as `into_reader_archive`, now constrained to `T: ReaderAt`
 - Rename `ZipSliceArchive::into_zip_archive` to `into_cursor_archive`
 - Remove `MissingZip64EndOfCentralDirectory` error kind as it is no longer possible to trigger
 - Relocate `ZipSliceEntry::{file_path,extra_fields}` behind lifetime accurate `ZipSliceEntry::local_header`

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -161,7 +161,7 @@ impl<T: AsRef<[u8]>> ZipSliceArchive<T> {
     ///
     /// This is only needed for `AsRef<[u8]>` types that do not themselves
     /// implement [`ReaderAt`], such as a memory-mapped file (`memmap2::Mmap`).
-    /// Otherwise prefer the zero-cost [`ZipSliceArchive::into_reader`].
+    /// Otherwise prefer the zero-cost [`ZipSliceArchive::into_reader_archive`].
     #[cfg(feature = "std")]
     pub fn into_cursor_archive(self) -> ZipArchive<std::io::Cursor<T>> {
         ZipArchive {

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -257,8 +257,10 @@ impl<T: ReaderAt> ZipSliceArchive<T> {
     ///
     /// This is useful for unifying code that might handle both slice-based and
     /// reader-based archives. Because the underlying data already implements
-    /// [`ReaderAt`], the conversion is zero-cost.
-    pub fn into_reader(self) -> ZipArchive<T> {
+    /// [`ReaderAt`], the conversion is zero-cost. For `AsRef<[u8]>` types that
+    /// do not implement [`ReaderAt`], use
+    /// [`ZipSliceArchive::into_cursor_archive`] instead.
+    pub fn into_reader_archive(self) -> ZipArchive<T> {
         ZipArchive::from(self)
     }
 }

--- a/tests/it/concurrent_tests.rs
+++ b/tests/it/concurrent_tests.rs
@@ -67,7 +67,7 @@ fn reader_api_decompresses_entries_in_parallel() {
     let data = build_two_entry_deflate_zip();
     let archive = ZipArchive::from_slice(data.as_slice())
         .unwrap()
-        .into_reader();
+        .into_reader_archive();
 
     let barrier = Arc::new(Barrier::new(2));
     let expected = [FIRST_CONTENT, SECOND_CONTENT];

--- a/tests/it/crc_tests.rs
+++ b/tests/it/crc_tests.rs
@@ -110,7 +110,7 @@ fn slice_verifying_reader() {
 #[test]
 fn reader_imperative_claim_verifier() {
     let data = build_deflate_zip(CONTENT);
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
 
@@ -131,7 +131,7 @@ fn reader_imperative_claim_verifier() {
 #[test]
 fn reader_verifying_reader() {
     let data = build_deflate_zip(CONTENT);
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
 
@@ -228,7 +228,7 @@ impl<R: ReaderAt, C: Checksum> Read for CustomCrcVerifier<R, C> {
 
 fn run_custom_crc_verifier_eof<C: Checksum>(crc: C) {
     let data = build_deflate_zip(CONTENT);
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let mut verifier = CustomCrcVerifier::new(ent.reader(), crc);
@@ -268,7 +268,7 @@ fn corrupt_central_crc_rejected() {
     assert_invalid_checksum(err, corrupted, original);
 
     // Reader verifier.
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let verifier = ent.verifying_reader(DeflateDecoder::new(ent.reader()));
@@ -309,7 +309,7 @@ fn data_descriptor_present_for_streamed_entry() {
     assert_eq!(dd.uncompressed_size(), central_uncompressed);
 
     // Reader path.
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let reader = ent.reader();
@@ -334,7 +334,7 @@ fn data_descriptor_absent_for_non_streamed_entry() {
     assert!(ent.data_descriptor().unwrap().is_none());
 
     // Reader path.
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let reader = ent.reader();
@@ -423,7 +423,7 @@ fn descriptor_cross_check_rejects_descriptor_divergence() {
     let read_limit = CONTENT.len() as u64 + 1;
 
     // The default verifying_reader keys off the central directory and succeeds.
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let verifier = ent.verifying_reader(DeflateDecoder::new(ent.reader()));
@@ -461,7 +461,7 @@ fn descriptor_cross_check_rejects_size_divergence() {
 
     // The default verifying_reader keys off the central directory (and never
     // consults the descriptor sizes), so it succeeds despite the corruption.
-    let archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let wayfinder = first_wayfinder(&archive);
     let ent = archive.get_entry(wayfinder).unwrap();
     let verifier = ent.verifying_reader(DeflateDecoder::new(ent.reader()));

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -880,10 +880,10 @@ fn zip_integration_tests_vec() {
     let data = std::fs::read("assets/zip64.zip").unwrap();
 
     // `Vec<u8>` implements `ReaderAt`, so it can be converted directly without a
-    // `Cursor` wrapper, both via `into_reader` and the `From`/`Into` impls.
+    // `Cursor` wrapper, both via `into_reader_archive` and the `From`/`Into` impls.
     let archive = rawzip::ZipArchive::from_slice(data.clone()).unwrap();
     assert_eq!(archive.comment().as_bytes(), b"");
-    let reader: rawzip::ZipArchive<Vec<u8>> = archive.into_reader();
+    let reader: rawzip::ZipArchive<Vec<u8>> = archive.into_reader_archive();
     assert_entry_count(reader, 1);
 
     let archive = rawzip::ZipArchive::from_slice(data).unwrap();
@@ -1185,7 +1185,7 @@ fn test_local_header_declared_fields_match_central_directory() {
     );
     assert_eq!(slice_local_header.last_modified(), entry.last_modified());
 
-    let reader_archive = ZipArchive::from_slice(&data).unwrap().into_reader();
+    let reader_archive = ZipArchive::from_slice(&data).unwrap().into_reader_archive();
     let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let mut reader_entries = reader_archive.entries(&mut buffer);
     let reader_entry = reader_entries.next_entry().unwrap().unwrap();
@@ -1242,7 +1242,9 @@ fn reader_local_header_returns_error_when_reread_diverges() {
         local_header_offset,
         local_header_reads: Cell::new(0),
     };
-    let reader_archive = ZipArchive::from_slice(divergent).unwrap().into_reader();
+    let reader_archive = ZipArchive::from_slice(divergent)
+        .unwrap()
+        .into_reader_archive();
     let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let mut entries = reader_archive.entries(&mut buffer);
     let entry_header = entries.next_entry().unwrap().unwrap();


### PR DESCRIPTION
Not an (additional) breaking change as this was already listed as a breaking change