### PR TITLE
Remove EntryPath as sole re-export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@ pub use headers::EntryFlags;
 pub use headers::Header;
 pub use locator::*;
 pub use mode::{CreatorSystem, EntryMode, VersionMadeBy};
-#[cfg(feature = "alloc")]
-pub use path::EntryPath;
 #[cfg(feature = "std")]
 pub use reader_at::{FileReader, RangeReader, ReaderAt};
 #[cfg(feature = "std")]

--- a/src/path.rs
+++ b/src/path.rs
@@ -436,7 +436,7 @@ impl ZipFilePath<NormalizedPathBuf> {
 /// # Examples
 ///
 /// ```rust
-/// use rawzip::EntryPath;
+/// use rawzip::path::EntryPath;
 ///
 /// // A UTF-8 path, normalized on write.
 /// let path = EntryPath::conformant("docs/readme.txt");

--- a/tests/it/entry_path_tests.rs
+++ b/tests/it/entry_path_tests.rs
@@ -1,4 +1,5 @@
-use rawzip::{EntryPath, ZipArchive, ZipArchiveWriter};
+use rawzip::path::EntryPath;
+use rawzip::{ZipArchive, ZipArchiveWriter};
 use std::io::Write;
 
 /// Writes one file and returns the archive.


### PR DESCRIPTION
Seeing it as the sole re-export made it feel out of place.

Not a breaking change as EntryPath did not exist before.