### PR TITLE
Fix: parse nameless entries at end of central directory

### DIFF
--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -533,7 +533,7 @@ where
     /// buffer to parse entry headers.
     #[inline]
     pub fn next_entry(&mut self) -> Result<Option<ZipFileHeaderRecord<'_>>, Error> {
-        if self.pos + ZipFileHeaderFixed::SIZE >= self.end {
+        if self.pos + ZipFileHeaderFixed::SIZE > self.end {
             if self.offset >= self.central_dir_end_pos {
                 return Ok(None);
             }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1441,3 +1441,29 @@ fn entry_overrunning_central_directory_is_eof() {
     let err = entries.next_entry().unwrap_err();
     assert!(matches!(err.kind(), rawzip::ErrorKind::Eof));
 }
+
+#[test]
+fn reader_parses_nameless_entry_at_boundary() {
+    const CENTRAL_DIRECTORY_HEADER_SIZE: usize = 46;
+
+    let mut data = Vec::new();
+    let mut writer = ZipArchiveWriter::new(&mut data);
+    for _ in 0..2 {
+        let (entry, config) = writer.new_file("").start().unwrap();
+        let (entry, descriptor) = config.wrap(entry).finish().unwrap();
+        entry.finish(descriptor).unwrap();
+    }
+    writer.finish().unwrap();
+
+    let slice = ZipArchive::from_slice(&data).unwrap();
+    assert_eq!(slice.entries().count(), 2);
+
+    let mut locator_buffer = vec![0; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let reader = rawzip::ZipLocator::new()
+        .locate_in_reader(data.as_slice(), &mut locator_buffer, data.len() as u64)
+        .unwrap();
+    let mut entry_buffer = [0; CENTRAL_DIRECTORY_HEADER_SIZE * 2];
+    let mut entries = reader.entries(&mut entry_buffer);
+    assert!(entries.next_entry().unwrap().is_some());
+    assert!(entries.next_entry().unwrap().is_some());
+}


### PR DESCRIPTION
A nameless zip entry (which is spec compliant) is exactly 46 bytes and if it occurred at the end of the central directory, rawzip would return an EOF