### PR TITLE
Harden zip64 detection against false positives

### DIFF
--- a/src/locator.rs
+++ b/src/locator.rs
@@ -103,7 +103,6 @@ impl ZipLocator {
         location: usize,
     ) -> Result<EndOfCentralDirectory, Error> {
         let eocd = EndOfCentralDirectoryRecordFixed::parse(&data[location..])?;
-        let eocd = EndOfCentralDirectoryRecord::from_parts(location as u64, eocd);
 
         // Validate comment is completely present in the slice
         let comment_start = location + EndOfCentralDirectoryRecordFixed::SIZE;
@@ -112,21 +111,37 @@ impl ZipLocator {
             return Err(Error::from(ErrorKind::Eof));
         }
 
-        // Always probe for a zip64 EOCD locator, which can be present
-        // even if a sentinel wasn't present.
+        // Always probe for a zip64 EOCD locator, which can be present without sentinels
         let zip64_locator = location
             .checked_sub(Zip64EndOfCentralDirectoryLocatorRecord::SIZE)
             .and_then(|start| Zip64EndOfCentralDirectoryLocatorRecord::parse(&data[start..]).ok());
 
         let Some(zip64_locator) = zip64_locator else {
-            return EndOfCentralDirectory::create(eocd);
+            return EndOfCentralDirectory::create(EndOfCentralDirectoryRecord::from_parts(
+                location as u64,
+                &eocd,
+            ));
         };
 
         let zip64_eocd = &data[(zip64_locator.directory_offset as usize).min(data.len())..];
-        let zip64_record = Zip64EndOfCentralDirectoryRecord::parse(zip64_eocd)?;
+        let zip64_record = match parse_zip64_candidate(
+            zip64_eocd,
+            &eocd,
+            &zip64_locator,
+            location as u64 - Zip64EndOfCentralDirectoryLocatorRecord::SIZE as u64,
+        ) {
+            Some(record) => record,
+            None => {
+                return EndOfCentralDirectory::create(EndOfCentralDirectoryRecord::from_parts(
+                    location as u64,
+                    &eocd,
+                ));
+            }
+        };
 
         let zip64 =
             Zip64EndOfCentralDirectory::from_parts(zip64_locator.directory_offset, zip64_record);
+        let eocd = EndOfCentralDirectoryRecord::from_parts(location as u64, &eocd);
         EndOfCentralDirectory::create_zip64(eocd, zip64)
     }
 
@@ -283,7 +298,7 @@ pub(crate) struct EndOfCentralDirectoryRecord {
 
 impl EndOfCentralDirectoryRecord {
     #[inline]
-    pub fn from_parts(offset: u64, eocd: EndOfCentralDirectoryRecordFixed) -> Self {
+    pub fn from_parts(offset: u64, eocd: &EndOfCentralDirectoryRecordFixed) -> Self {
         Self {
             offset,
             central_dir_size: eocd.central_dir_size,
@@ -381,6 +396,38 @@ impl Zip64EndOfCentralDirectoryLocatorRecord {
 
         Ok(result)
     }
+}
+
+fn parse_zip64_candidate(
+    data: &[u8],
+    classic: &EndOfCentralDirectoryRecordFixed,
+    locator: &Zip64EndOfCentralDirectoryLocatorRecord,
+    locator_offset: u64,
+) -> Option<Zip64EndOfCentralDirectoryRecord> {
+    const ZIP64_SIZE_PREFIX: u64 = 12;
+    const ZIP64_MIN_SIZE: u64 = Zip64EndOfCentralDirectoryRecord::SIZE as u64 - ZIP64_SIZE_PREFIX;
+
+    let zip64 = Zip64EndOfCentralDirectoryRecord::parse(data).ok()?;
+
+    if zip64.size < ZIP64_MIN_SIZE {
+        return None;
+    }
+
+    let record_end = locator
+        .directory_offset
+        .checked_add(ZIP64_SIZE_PREFIX)?
+        .checked_add(zip64.size)?;
+
+    let consistent = record_end == locator_offset
+        && (classic.num_entries == u16::MAX || u64::from(classic.num_entries) == zip64.num_entries)
+        && (classic.total_entries == u16::MAX
+            || u64::from(classic.total_entries) == zip64.total_entries)
+        && (classic.central_dir_size == u32::MAX
+            || u64::from(classic.central_dir_size) == zip64.central_dir_size)
+        && (classic.central_dir_offset == u32::MAX
+            || u64::from(classic.central_dir_offset) == zip64.central_dir_offset);
+
+    consistent.then_some(zip64)
 }
 
 pub(crate) fn find_end_of_central_dir_signature(

--- a/src/locator/reader.rs
+++ b/src/locator/reader.rs
@@ -222,17 +222,14 @@ impl ZipLocator {
             }
         }
 
-        let eocd = EndOfCentralDirectoryRecord::from_parts(eocd_offset, eocd);
-
         let eocd64l_size = Zip64EndOfCentralDirectoryLocatorRecord::SIZE;
 
-        // Always probe for a zip64 EOCD locator, which can be present
-        // even if a sentinel wasn't present.
+        // Always probe for a zip64 EOCD locator, which can be present without sentinels
         if (eocd64l_size as u64) > eocd_offset {
-            return match EndOfCentralDirectory::create(eocd) {
-                Ok(eocd) => Ok((reader.inner, eocd)),
-                Err(e) => Err((reader.inner, e)),
-            };
+            return finish_classic_eocd(
+                reader,
+                EndOfCentralDirectoryRecord::from_parts(eocd_offset, &eocd),
+            );
         }
 
         // Unhappy path: if we needed to issue any reads since the original
@@ -255,10 +252,10 @@ impl ZipLocator {
         let zip64_locator = match Zip64EndOfCentralDirectoryLocatorRecord::parse(zip64l_eocd) {
             Ok(locator) => locator,
             Err(_) => {
-                return match EndOfCentralDirectory::create(eocd) {
-                    Ok(eocd) => Ok((reader.inner, eocd)),
-                    Err(e) => Err((reader.inner, e)),
-                };
+                return finish_classic_eocd(
+                    reader,
+                    EndOfCentralDirectoryRecord::from_parts(eocd_offset, &eocd),
+                );
             }
         };
 
@@ -277,9 +274,16 @@ impl ZipLocator {
 
             match read {
                 Ok(read) => (0, read),
-                Err(e) => {
-                    return Err((reader.inner, Error::io(e)));
+                // If a false positive ZIP64 points outside the available data,
+                // treat it as a false-positive locator and use the classic
+                // EOCD. Propagate other I/O failures.
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return finish_classic_eocd(
+                        reader,
+                        EndOfCentralDirectoryRecord::from_parts(eocd_offset, &eocd),
+                    );
                 }
+                Err(e) => return Err((reader.inner, Error::io(e))),
             }
         } else {
             (
@@ -289,19 +293,40 @@ impl ZipLocator {
         };
 
         let zip64_eocd = &buffer[eocd64_start..eocd64_end];
-        let zip64_record = match Zip64EndOfCentralDirectoryRecord::parse(zip64_eocd) {
-            Ok(record) => record,
-            Err(e) => return Err((reader.inner, e)),
+        let zip64_record = match super::parse_zip64_candidate(
+            zip64_eocd,
+            &eocd,
+            &zip64_locator,
+            eocd_offset - eocd64l_size as u64,
+        ) {
+            Some(record) => record,
+            None => {
+                return finish_classic_eocd(
+                    reader,
+                    EndOfCentralDirectoryRecord::from_parts(eocd_offset, &eocd),
+                );
+            }
         };
 
         // todo: zip64 extensible data sector
 
         let zip_eocd =
             Zip64EndOfCentralDirectory::from_parts(zip64_locator.directory_offset, zip64_record);
+        let eocd = EndOfCentralDirectoryRecord::from_parts(eocd_offset, &eocd);
         match EndOfCentralDirectory::create_zip64(eocd, zip_eocd) {
             Ok(eocd) => Ok((reader.inner, eocd)),
             Err(e) => Err((reader.inner, e)),
         }
+    }
+}
+
+fn finish_classic_eocd<R>(
+    reader: Marker<R>,
+    eocd: EndOfCentralDirectoryRecord,
+) -> Result<(R, EndOfCentralDirectory), (R, Error)> {
+    match EndOfCentralDirectory::create(eocd) {
+        Ok(eocd) => Ok((reader.inner, eocd)),
+        Err(e) => Err((reader.inner, e)),
     }
 }
 

--- a/tests/it/false_sentinel_tests.rs
+++ b/tests/it/false_sentinel_tests.rs
@@ -1,9 +1,12 @@
-use rawzip::{RECOMMENDED_BUFFER_SIZE, ZipArchive};
+use rawzip::{
+    ErrorKind, RECOMMENDED_BUFFER_SIZE, ReaderAt, ZipArchive, ZipArchiveWriter, ZipLocator,
+};
 use std::io::Cursor;
 
 const LFH_SIG: u32 = 0x0403_4b50;
 const CDH_SIG: u32 = 0x0201_4b50;
 const EOCD_SIG: u32 = 0x0605_4b50;
+const ZIP64_LOCATOR_SIG: u32 = 0x0706_4b50;
 
 /// Minimal raw ZIP byte builder for stored, empty entries. Keeps total size
 /// small so even a 65535-entry archive stays a few MiB and well under 4 GiB.
@@ -27,7 +30,6 @@ impl RawZip {
     fn push32(&mut self, v: u32) {
         self.buf.extend_from_slice(&v.to_le_bytes());
     }
-
     /// Append a local file header for a stored, empty file.
     fn add_local(&mut self, name: &[u8]) {
         let offset = self.buf.len() as u32;
@@ -48,10 +50,15 @@ impl RawZip {
 
     /// Append the central directory for all previously added locals, returning
     /// (central_dir_offset, central_dir_size).
-    fn write_central_directory(&mut self) -> (u32, u32) {
+    fn write_central_directory_with_comment(&mut self, comment: &[u8]) -> (u32, u32) {
         let cd_start = self.buf.len() as u32;
         let locals = std::mem::take(&mut self.locals);
-        for (name, local_offset) in &locals {
+        for (index, (name, local_offset)) in locals.iter().enumerate() {
+            let comment = if index + 1 == locals.len() {
+                comment
+            } else {
+                &[]
+            };
             self.push32(CDH_SIG);
             self.push16(20); // version made by
             self.push16(20); // version needed
@@ -64,12 +71,13 @@ impl RawZip {
             self.push32(0); // uncompressed size
             self.push16(name.len() as u16);
             self.push16(0); // extra len
-            self.push16(0); // comment len
+            self.push16(comment.len() as u16);
             self.push16(0); // disk number start
             self.push16(0); // internal attrs
             self.push32(0); // external attrs
             self.push32(*local_offset);
             self.buf.extend_from_slice(name);
+            self.buf.extend_from_slice(comment);
         }
         let cd_size = self.buf.len() as u32 - cd_start;
         (cd_start, cd_size)
@@ -91,14 +99,27 @@ impl RawZip {
 /// A conformant non-zip64 archive with exactly 65535 entries. The EOCD entry
 /// count equals the 0xFFFF sentinel, but there is deliberately no zip64 record.
 fn build_65535_non_zip64() -> Vec<u8> {
+    build_65535_non_zip64_with_comment(&[])
+}
+
+fn build_65535_non_zip64_with_comment(comment: &[u8]) -> Vec<u8> {
     const N: usize = 65535;
     let mut z = RawZip::new();
     for i in 0..N {
         z.add_local(format!("{i}").as_bytes());
     }
-    let (cd_offset, cd_size) = z.write_central_directory();
+    let (cd_offset, cd_size) = z.write_central_directory_with_comment(comment);
     z.write_eocd(N as u16, cd_size, cd_offset);
     z.buf
+}
+
+fn locator_comment(zip64_eocd_offset: u64) -> Vec<u8> {
+    let mut comment = Vec::new();
+    comment.extend_from_slice(&ZIP64_LOCATOR_SIG.to_le_bytes());
+    comment.extend_from_slice(&0u32.to_le_bytes());
+    comment.extend_from_slice(&zip64_eocd_offset.to_le_bytes());
+    comment.extend_from_slice(&1u32.to_le_bytes());
+    comment
 }
 
 fn count_slice_entries(data: &[u8]) -> usize {
@@ -138,4 +159,127 @@ fn read_65535_entry_non_zip64_slice() {
 fn read_65535_entry_non_zip64_reader() {
     let data = build_65535_non_zip64();
     assert_eq!(count_reader_entries(&data), 65535);
+}
+
+#[test]
+fn locator_shaped_comment_on_65535_entry_classic_zip_is_not_zip64() {
+    let data = build_65535_non_zip64_with_comment(&locator_comment(u64::MAX));
+    assert_eq!(count_slice_entries(&data), 65535);
+    assert_eq!(count_reader_entries(&data), 65535);
+}
+
+fn classic_zip_with_locator_comment(zip64_eocd_offset: u64) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut archive = ZipArchiveWriter::new(&mut data);
+    let (entry, config) = archive
+        .new_file("x")
+        .comment(locator_comment(zip64_eocd_offset))
+        .start()
+        .unwrap();
+    let (entry, descriptor) = config.wrap(entry).finish().unwrap();
+    entry.finish(descriptor).unwrap();
+    archive.finish().unwrap();
+    data
+}
+
+#[test]
+fn locator_shaped_trailing_bytes_do_not_make_classic_zip_zip64() {
+    let data = classic_zip_with_locator_comment(0);
+
+    assert_eq!(count_slice_entries(&data), 1);
+    assert_eq!(count_reader_entries(&data), 1);
+}
+
+#[test]
+fn out_of_range_zip64_candidate_falls_back_to_classic_reader() {
+    let data = classic_zip_with_locator_comment(u64::MAX);
+    assert_eq!(count_reader_entries(&data), 1);
+}
+
+#[derive(Debug)]
+struct FailingReader {
+    data: Vec<u8>,
+    fail_offset: u64,
+    error_kind: std::io::ErrorKind,
+}
+
+impl ReaderAt for FailingReader {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        if offset == self.fail_offset {
+            return Err(std::io::Error::new(
+                self.error_kind,
+                "injected read failure",
+            ));
+        }
+
+        self.data.as_slice().read_at(buf, offset)
+    }
+}
+
+fn empty_classic_eocd(prefix: Vec<u8>) -> Vec<u8> {
+    let mut z = RawZip {
+        buf: prefix,
+        locals: Vec::new(),
+    };
+    z.write_eocd(0, 0, 0);
+    z.buf
+}
+
+#[test]
+fn reader_error_while_probing_zip64_locator_is_propagated() {
+    let data = empty_classic_eocd(vec![0; 20]);
+    let reader = FailingReader {
+        data,
+        fail_offset: 0,
+        error_kind: std::io::ErrorKind::Other,
+    };
+    let mut buffer = [0; 22];
+
+    let (_, err) = ZipLocator::new()
+        .locate_in_reader(reader, &mut buffer, 42)
+        .unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::IO(e) if e.kind() == std::io::ErrorKind::Other));
+}
+
+fn classic_eocd_with_locator(zip64_eocd_offset: u64) -> Vec<u8> {
+    let mut prefix = vec![0; 56];
+    prefix.extend_from_slice(&ZIP64_LOCATOR_SIG.to_le_bytes());
+    prefix.extend_from_slice(&0u32.to_le_bytes());
+    prefix.extend_from_slice(&zip64_eocd_offset.to_le_bytes());
+    prefix.extend_from_slice(&1u32.to_le_bytes());
+    empty_classic_eocd(prefix)
+}
+
+#[test]
+fn reader_error_while_fetching_zip64_candidate_is_propagated() {
+    let data = classic_eocd_with_locator(0);
+    let end_offset = data.len() as u64;
+    let reader = FailingReader {
+        data,
+        fail_offset: 0,
+        error_kind: std::io::ErrorKind::Other,
+    };
+    let mut buffer = [0; 46];
+
+    let (_, err) = ZipLocator::new()
+        .locate_in_reader(reader, &mut buffer, end_offset)
+        .unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::IO(e) if e.kind() == std::io::ErrorKind::Other));
+}
+
+#[test]
+fn unexpected_eof_while_fetching_zip64_candidate_falls_back_to_classic() {
+    let data = classic_eocd_with_locator(0);
+    let end_offset = data.len() as u64;
+    let reader = FailingReader {
+        data,
+        fail_offset: 0,
+        error_kind: std::io::ErrorKind::UnexpectedEof,
+    };
+    let mut buffer = [0; 46];
+
+    let archive = ZipLocator::new()
+        .locate_in_reader(reader, &mut buffer, end_offset)
+        .unwrap();
+    assert_eq!(archive.entries_hint(), 0);
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1063,38 +1063,15 @@ fn test_should_not_overflow_on_offsets() {
         0, 80, 75, 5, 6, 0, 0, 0, 64, 255, 255, 0, 0, 8, 0, 53, 116, 10, 65, 126, 231, 0, 0, 0, 0,
         7, 0, 0, 0, 0, 144, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0,
     ];
-    let result = rawzip::ZipArchive::from_slice(&data).unwrap();
-    let entries = result.entries();
-    let mut has_error = false;
-
-    for entry in entries {
-        let Ok(entry) = entry else {
-            has_error = true;
-            break;
-        };
-        has_error |= result.get_entry(entry.wayfinder()).is_err();
-    }
-    assert!(has_error);
+    assert!(rawzip::ZipArchive::from_slice(&data).is_err());
 
     let mut buf = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
     let locator = rawzip::ZipLocator::new();
-    let result = locator
-        .locate_in_reader(&data[..], &mut buf, data.len() as u64)
-        .unwrap();
-    let mut entries = result.entries(&mut buf);
-    let mut has_error = false;
-
-    loop {
-        let Ok(entry) = entries.next_entry() else {
-            has_error = true;
-            break;
-        };
-        let Some(entry) = entry else {
-            break;
-        };
-        has_error |= result.get_entry(entry.wayfinder()).is_err();
-    }
-    assert!(has_error);
+    assert!(
+        locator
+            .locate_in_reader(&data[..], &mut buf, data.len() as u64)
+            .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
If we are always proping for zip64 EOCD then we should harden against false positives (like if a CD entry has a comment that contains the same signature)