### PR TITLE
Allow parsing of central directory digital signature

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -23,6 +23,9 @@ pub use reader::{ZipEntries, ZipEntry, ZipReader, ZipSliceVerifier, ZipVerifier}
 pub(crate) const END_OF_CENTRAL_DIR_SIGNATURE64: u32 = 0x06064b50;
 pub(crate) const END_OF_CENTRAL_DIR_LOCATOR_SIGNATURE: u32 = 0x07064b50;
 pub(crate) const CENTRAL_HEADER_SIGNATURE: u32 = 0x02014b50;
+pub(crate) const DIGITAL_SIGNATURE: u32 = 0x05054b50;
+pub(crate) const DIGITAL_SIGNATURE_BYTES: [u8; 4] = DIGITAL_SIGNATURE.to_le_bytes();
+const MAX_DIGITAL_SIGNATURE_SIZE: usize = 6 + u16::MAX as usize;
 
 /// The recommended buffer size to use when reading from a zip file.
 ///
@@ -364,11 +367,22 @@ impl<'data> ZipSliceEntries<'data> {
     /// Yield the next zip file entry in the central directory if there is any
     #[inline]
     pub fn next_entry(&mut self) -> Result<Option<ZipFileHeaderRecord<'data>>, Error> {
+        self.next_file_entry()
+    }
+
+    // Use inline always as this improved slice extraction of 100k entries by 14%.
+    // The reason why is that the return value is large and if the caller only wants
+    // the wayfinder then there is no need to materialize all the fields.
+    #[inline(always)]
+    fn next_file_entry(&mut self) -> Result<Option<ZipFileHeaderRecord<'data>>, Error> {
         if self.entry_data.is_empty() {
             return Ok(None);
         }
 
-        let file_header = ZipFileHeaderFixed::parse(self.entry_data)?;
+        let file_header = match ZipFileHeaderFixed::parse(self.entry_data) {
+            Ok(file_header) => file_header,
+            Err(err) => return self.next_entry_terminator(err),
+        };
         let Some((file_name, extra_field, file_comment, entry_data)) =
             file_header.parse_variable_length(&self.entry_data[ZipFileHeaderFixed::SIZE..])
         else {
@@ -386,6 +400,26 @@ impl<'data> ZipSliceEntries<'data> {
         self.current_offset += (self.entry_data.len() - entry_data.len()) as u64;
         self.entry_data = entry_data;
         Ok(Some(entry))
+    }
+
+    /// Handle a record that does not start with the central directory file
+    /// header signature.
+    ///
+    /// A digital signature record cleanly terminates iteration; anything else
+    /// is a genuine parse error.
+    #[cold]
+    #[inline(never)]
+    fn next_entry_terminator(
+        &mut self,
+        err: Error,
+    ) -> Result<Option<ZipFileHeaderRecord<'data>>, Error> {
+        if self.entry_data.len() <= MAX_DIGITAL_SIGNATURE_SIZE
+            && self.entry_data.starts_with(&DIGITAL_SIGNATURE_BYTES)
+        {
+            self.entry_data = &[];
+            return Ok(None);
+        }
+        Err(err)
     }
 }
 

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -533,9 +533,19 @@ where
     /// buffer to parse entry headers.
     #[inline]
     pub fn next_entry(&mut self) -> Result<Option<ZipFileHeaderRecord<'_>>, Error> {
+        self.next_entry_impl()
+    }
+
+    // While inline always for the reader variant isn't as strong as the slice for the
+    // extraction benchmark, it is still yielded as 12% improvement when just iterating.
+    #[inline(always)]
+    fn next_entry_impl(&mut self) -> Result<Option<ZipFileHeaderRecord<'_>>, Error> {
         if self.pos + ZipFileHeaderFixed::SIZE > self.end {
             if self.offset >= self.central_dir_end_pos {
                 return if self.pos == self.end {
+                    Ok(None)
+                } else if self.buffer[self.pos..self.end].starts_with(&DIGITAL_SIGNATURE_BYTES) {
+                    self.pos = self.end;
                     Ok(None)
                 } else {
                     Err(Error::from(ErrorKind::Eof))
@@ -546,9 +556,10 @@ where
             self.buffer.copy_within(self.pos..self.end, 0);
             let max_read = ((self.central_dir_end_pos - self.offset) as usize)
                 .min(self.buffer.len() - remaining);
+            let min_read = ZipFileHeaderFixed::SIZE.min(remaining + max_read) - remaining;
             let read = self.archive.reader.read_at_least_at(
                 &mut self.buffer[remaining..][..max_read],
-                ZipFileHeaderFixed::SIZE,
+                min_read,
                 self.offset,
             )?;
             self.offset += read as u64;
@@ -558,7 +569,10 @@ where
 
         let central_directory_offset = self.offset - (self.end - self.pos) as u64;
         let data = &self.buffer[self.pos..self.end];
-        let file_header = ZipFileHeaderFixed::parse(data)?;
+        let file_header = match ZipFileHeaderFixed::parse(data) {
+            Ok(file_header) => file_header,
+            Err(err) => return self.next_entry_terminator(err),
+        };
         self.pos += ZipFileHeaderFixed::SIZE;
 
         let variable_length = file_header.variable_length();
@@ -607,6 +621,28 @@ where
         file_header.local_header_offset += self.base_offset;
         self.pos += variable_length;
         Ok(Some(file_header))
+    }
+
+    /// Handle a record that does not start with the central directory file
+    /// header signature.
+    ///
+    /// A digital signature record cleanly terminates iteration; anything else
+    /// is a genuine parse error.
+    #[cold]
+    #[inline(never)]
+    fn next_entry_terminator(
+        &mut self,
+        err: Error,
+    ) -> Result<Option<ZipFileHeaderRecord<'_>>, Error> {
+        let central_directory_offset = self.offset - (self.end - self.pos) as u64;
+        if self.central_dir_end_pos - central_directory_offset <= MAX_DIGITAL_SIGNATURE_SIZE as u64
+            && self.buffer[self.pos..self.end].starts_with(&DIGITAL_SIGNATURE_BYTES)
+        {
+            self.pos = self.end;
+            self.offset = self.central_dir_end_pos;
+            return Ok(None);
+        }
+        Err(err)
     }
 }
 

--- a/tests/it/extra_data_zip_tests.rs
+++ b/tests/it/extra_data_zip_tests.rs
@@ -1,6 +1,65 @@
+use rawzip::path::EntryPath;
 use rawzip::{ZipArchive, ZipArchiveWriter};
 use rstest::rstest;
 use std::io::{Cursor, Write};
+
+/// Size of an end-of-central-directory record that carries no comment.
+const EOCD_SIZE: usize = 22;
+
+/// A digital signature record (`PK\x05\x05`) wrapping `payload`.
+fn digital_signature_record(payload: &[u8]) -> Vec<u8> {
+    let mut record = Vec::from(*b"PK\x05\x05");
+    record.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+    record.extend_from_slice(payload);
+    record
+}
+
+/// Build a single-entry zip, splicing `trailer` between the central directory
+/// and the EOCD and growing the recorded central directory size to cover it.
+///
+/// The writer never emits a digital signature record itself, so we construct
+/// one here where every offset is known by construction rather than recovered
+/// by scanning the bytes.
+fn zip_with_cd_trailer<'a>(name: impl Into<EntryPath<'a>>, trailer: &[u8]) -> Vec<u8> {
+    let mut data = Vec::new();
+    {
+        let mut archive = ZipArchiveWriter::new(&mut data);
+        let (mut entry, config) = archive.new_file(name).start().unwrap();
+        let mut writer = config.wrap(&mut entry);
+        writer.write_all(b"contents").unwrap();
+        let (_, descriptor) = writer.finish().unwrap();
+        entry.finish(descriptor).unwrap();
+        archive.finish().unwrap();
+    }
+
+    let eocd = data.len() - EOCD_SIZE;
+    let cd_size = u32::from_le_bytes(data[eocd + 12..eocd + 16].try_into().unwrap());
+    data[eocd + 12..eocd + 16].copy_from_slice(&(cd_size + trailer.len() as u32).to_le_bytes());
+    data.splice(eocd..eocd, trailer.iter().copied());
+    data
+}
+
+/// Collect the entry file paths, asserting the slice and reader readers agree.
+fn entry_paths(data: &[u8]) -> Vec<Vec<u8>> {
+    let slice: Vec<Vec<u8>> = ZipArchive::from_slice(data)
+        .unwrap()
+        .entries()
+        .map(|entry| entry.unwrap().file_path().as_ref().to_vec())
+        .collect();
+
+    let mut buffer = vec![0; rawzip::RECOMMENDED_BUFFER_SIZE];
+    let archive = rawzip::ZipLocator::new()
+        .locate_in_reader(data, &mut buffer, data.len() as u64)
+        .unwrap();
+    let mut entries = archive.entries(&mut buffer);
+    let mut reader = Vec::new();
+    while let Some(entry) = entries.next_entry().unwrap() {
+        reader.push(entry.file_path().as_ref().to_vec());
+    }
+
+    assert_eq!(slice, reader, "slice and reader readers disagree");
+    slice
+}
 
 /// Helper function to find the start of ZIP data by finding the minimum local header offset
 fn find_zip_data_start_offset_slice<T: AsRef<[u8]>>(archive: &rawzip::ZipSliceArchive<T>) -> u64 {
@@ -166,4 +225,26 @@ fn test_zip_declared_prelude(#[case] entry_count: usize) {
     let zip_start_offset = find_zip_data_start_offset_slice(&archive);
     assert_eq!(zip_start_offset, 1000);
     assert_eq!(archive.entries().count(), entry_count);
+}
+
+#[test]
+fn central_directory_digital_signature() {
+    let data = zip_with_cd_trailer("README", &digital_signature_record(b"signed"));
+    assert_eq!(entry_paths(&data), [b"README".to_vec()]);
+}
+
+#[test]
+fn truncated_central_directory_digital_signature() {
+    // A degenerate record: only the 4-byte marker, with no size or payload.
+    let data = zip_with_cd_trailer("README", b"PK\x05\x05");
+    assert_eq!(entry_paths(&data), [b"README".to_vec()]);
+}
+
+#[test]
+fn digital_signature_marker_inside_record_data() {
+    // The marker appears both in a file name and inside the signature payload;
+    // neither should be mistaken for the terminator.
+    let name = EntryPath::verbatim(b"PK\x05\x05ME".as_slice());
+    let data = zip_with_cd_trailer(name, &digital_signature_record(b"PK\x05\x05"));
+    assert_eq!(entry_paths(&data), [b"PK\x05\x05ME".to_vec()]);
 }


### PR DESCRIPTION
Section 4.3.13 allows a digital signature to follow the end of the central directory. We should follow SharpZipLib by cleaning terminating CD iteration when the signature is encountered (as we're done anyhow)

Along for the ride are performance improvements! The return value of all the fields in the central directory is "large" by forcing inlining, the compiler can see through what fields are actually used. This yielded a 14% improvement on the slice extraction benchmark

No real fixture added as I couldn't find one 🤷 
I believe it is due to needing a bit of a license for SecureZip